### PR TITLE
feat: add Tauon template

### DIFF
--- a/tauon/tauon.txt
+++ b/tauon/tauon.txt
@@ -1,0 +1,110 @@
+#Tauon Music Box theme file
+
+#-Backgrounds------
+
+{{colors.surface.default.rgb_csv}},180      top panel
+{{colors.surface.default.rgb_csv}},180      tracklist panel
+{{colors.surface.default.rgb_csv}},180      side panel
+{{colors.surface_variant.default.rgb_csv}},180      bottom panel
+{{colors.surface.default.rgb_csv}},180      queue panel
+{{colors.surface.default.rgb_csv}},180      gallery background
+
+#-Playlist---------
+
+{{colors.on_surface.default.rgb_csv}}       track line
+{{colors.on_surface.default.rgb_csv}}       track time
+{{colors.on_surface.default.rgb_csv}}       track index
+{{colors.primary.default.rgb_csv}}       track artist
+{{colors.tertiary.default.rgb_csv}}       track album
+
+{{colors.primary.default.rgb_csv}}       track playing
+{{colors.primary.default.rgb_csv}}       index playing
+{{colors.primary.default.rgb_csv}}       artist playing
+{{colors.primary.default.rgb_csv}}       album playing
+{{colors.primary.default.rgb_csv}}       time playing
+
+{{colors.error.default.rgb_csv}}       track missing
+
+{{colors.primary.default.rgb_csv}}       fav line
+{{colors.outline.default.rgb_csv}}          folder line
+{{colors.tertiary.default.rgb_csv}}       folder title
+
+{{colors.secondary.default.rgb_csv}},120      playing highlight
+{{colors.tertiary.default.rgb_csv}},60    select highlight
+{{colors.primary.default.rgb_csv}}       gallery highlight
+
+{{colors.secondary.default.rgb_csv}}          column bar background
+
+#-Menu-------------
+
+{{colors.surface.default.rgb_csv}},240      menu background
+{{colors.on_surface.default.rgb_csv}},60      menu highlight
+{{colors.outline.default.rgb_csv}}       menu border
+{{colors.on_surface.default.rgb_csv}}       menu text
+{{colors.error.default.rgb_csv}},60         menu disable text
+{{colors.primary.default.rgb_csv}}         menu icons
+
+#-Top Panel--------
+
+{{colors.secondary.default.rgb_csv}}          tab active text
+{{colors.on_surface.default.rgb_csv}}       tab text
+{{colors.secondary.default.rgb_csv}},120          tab over
+{{colors.tertiary.default.rgb_csv}},120       tab active background
+{{colors.surface.default.rgb_csv}},210      tab background
+{{colors.primary.default.rgb_csv}}       music vis
+
+{{colors.surface.default.rgb_csv}},210      window buttons background
+{{colors.surface.default.rgb_csv}}          window buttons off
+{{colors.on_surface.default.rgb_csv}}        window buttons on
+{{colors.primary.default.rgb_csv}}          window buttons icon over
+
+#-Bottom Panel-----
+
+{{colors.surface.default.rgb_csv}},190      buttons off
+{{colors.primary.default.rgb_csv}}       buttons over
+{{colors.on_surface.default.rgb_csv}}       buttons active
+
+{{colors.primary.default.rgb_csv}}       playing time
+
+{{colors.primary.default.rgb_csv}}       seek bar
+{{colors.surface.default.rgb_csv}}          seek bg
+{{colors.surface.default.rgb_csv}}          volume bg
+{{colors.primary.default.rgb_csv}}       volume bar
+{{colors.tertiary.default.rgb_csv}}       scroll bar
+
+{{colors.surface.default.rgb_csv}},170      mode off
+{{colors.primary.default.rgb_csv}}       mode over
+{{colors.on_surface.default.rgb_csv}}       mode on
+
+{{colors.primary.default.rgb_csv}}       bottom title
+
+#-Dialog Box-------
+
+{{colors.surface.default.rgb_csv}},240      box background
+{{colors.outline.default.rgb_csv}}       box border
+{{colors.tertiary.default.rgb_csv}}       box title text
+{{colors.on_surface.default.rgb_csv}}       box text label
+{{colors.on_surface.default.rgb_csv}}       box text normal
+{{colors.on_surface.default.rgb_csv}}       box sub text
+{{colors.on_surface.default.rgb_csv}}       box input text
+{{colors.outline.default.rgb_csv}}           box text border
+{{colors.outline.default.rgb_csv}},200      box button background normal
+{{colors.primary.default.rgb_csv}}         box button background highlight
+{{colors.outline.default.rgb_csv}}          box button border
+
+#-Artist Info-------
+{{colors.surface.default.rgb_csv}},220      artist bio background
+{{colors.on_surface.default.rgb_csv}}       artist bio text
+
+#-Side Panel-------
+
+{{colors.primary.default.rgb_csv}}       title info
+{{colors.on_surface.default.rgb_csv}}       extra info
+{{colors.outline.default.rgb_csv}},160   art border
+
+#-Mini Mode--------
+
+{{colors.surface.default.rgb_csv}},210      mini bg
+{{colors.outline.default.rgb_csv}}       mini border
+{{colors.on_primary.default.rgb_csv}}       mini text 1
+{{colors.secondary.default.rgb_csv}}        mini text 2

--- a/tauon/template.toml
+++ b/tauon/template.toml
@@ -1,0 +1,7 @@
+[catalog.tauon]
+name = "Tauon"
+category = "audio"
+
+[templates.tauon]
+input_path = "tauon.txt"
+output_path = "~/.local/share/TauonMusicBox/theme/Noctalia.ttheme"


### PR DESCRIPTION
A template for Tauon Music Box audio player.
Syncs Tauon to match Noctalia's theme colors.
Should work on both Noctalia v4 and v5.

It doesn't seem that Tauon supports hot-reloading of its themes at the moment.
The user can select the theme in its settings, and force a UI refresh using F10.