### PR TITLE
[Fix] Call papirus-folders with bash instead

### DIFF
--- a/papirus-icons/apply.sh
+++ b/papirus-icons/apply.sh
@@ -53,5 +53,5 @@ set -euo pipefail
   fi
  
   # 6. Apply icons instantly
-  [[ -n "$closest" ]] && "$(dirname "$0")/papirus-folders" -C "$closest" || echo "Error: Failed to apply papirus-folders"
+  [[ -n "$closest" ]] && bash "$(dirname "$0")/papirus-folders" -C "$closest" || echo "Error: Failed to apply papirus-folders"
 }


### PR DESCRIPTION
Templates in the cache directory do not apply the executable file attribute when downloaded. Only merge this if this is not working around a bug that needs fixed elsewhere.
