### PR TITLE
fix(neovim): grep guard never matches, appends duplicate to init.lua

### DIFF
--- a/neovim/apply.sh
+++ b/neovim/apply.sh
@@ -20,15 +20,14 @@ return { 'RRethy/base16-nvim',
 EOF
     fi
 else
-    echo "lazy.nvim not installed. Install RRethy/base16-nvim maunally." >&2
-fi
-
-if [ -f "$init_lua" ] && ! grep -qF "pcall(require, 'matugen')" "$init_lua"; then
-    cat >> "$init_lua" <<'EOF'
+    echo "lazy.nvim not installed. Install RRethy/base16-nvim manually." >&2
+    if [ -f "$init_lua" ] && ! grep -qF "pcall(require, 'matugen')" "$init_lua"; then
+        cat >> "$init_lua" <<'EOF'
 
 local ok, matugen = pcall(require, 'matugen')
 if ok then matugen.setup() end
 EOF
+    fi
 fi
 
 pkill -SIGUSR1 nvim >/dev/null 2>&1 || true

--- a/neovim/apply.sh
+++ b/neovim/apply.sh
@@ -23,7 +23,7 @@ else
     echo "lazy.nvim not installed. Install RRethy/base16-nvim maunally." >&2
 fi
 
-if [ -f "$init_lua" ] && ! grep -q "require('matugen')" "$init_lua"; then
+if [ -f "$init_lua" ] && ! grep -qF "pcall(require, 'matugen')" "$init_lua"; then
     cat >> "$init_lua" <<'EOF'
 
 local ok, matugen = pcall(require, 'matugen')


### PR DESCRIPTION
     Fix Neovim init.lua duplicate lines & LazyVim support                                                                                                       
                                                                                                                                                               
   Two fixes in apply.sh:                                                                                                                                      
                                                                                                                                                               
   1. Skip init.lua append for LazyVim users                                                                                                                   
      LazyVim auto-loads plugins from lua/plugins/ — appending                                                                                                 
      require() to init.lua is redundant. Moved the init.lua                                                                                                   
      append into the non-LazyVim branch so LazyVim users                                                                                                      
      get a clean init.lua.                                                                                                                                    
                                                                                                                                                               
   2. Fix idempotent guard preventing duplicates                                                                                                               
      grep matched require('matugen') but actual inserted code                                                                                                 
      is pcall(require, 'matugen') — the comma+space broke                                                                                                     
      the substring match. Every theme switch appended another                                                                                                 
      block. Fixed to match the real inserted string.                                                                                                          
                                                                                                                                                               
   Result:                                                                                                                                                     
   - LazyVim: plugin file only, init.lua untouched                                                                                                             
   - Other setups: init.lua updated once, no duplicates 