### PR TITLE
Add support for Gram

### DIFF
--- a/zed/template.toml
+++ b/zed/template.toml
@@ -5,3 +5,7 @@ category = "editor"
 [templates.zed]
 input_path = "zed.json"
 output_path = "$XDG_CONFIG_HOME/zed/themes/noctalia.json"
+
+[templates.gram]
+input_path = "zed.json"
+output_path = "$XDG_CONFIG_HOME/gram/themes/noctalia.json"


### PR DESCRIPTION
Essentially just adding an extra hook for Gram.

Putting images below just in case someone can spot inconsistencies as Gram uses wgpu for rendering per [1.1.0](https://gram-editor.com/posts/release-1-1-0/) instead of Zed's Blade. I don't see a difference but some may have keener eyes than I do.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/99c5e063-95d1-40a7-b57d-c10b0ce7814d" /> 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ed301588-8f6d-46e6-94f0-88ea477d6765" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/958c95ae-f4dd-4f28-80c2-5d5b7c3eaf07" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/21d6c9c1-ed1a-47d1-9f54-05832bc7024e" />
