### PR TITLE
fix(discord-midnight): improve channel text contrast and accent color mappings

### DIFF
--- a/discord/discord-midnight.css
+++ b/discord/discord-midnight.css
@@ -81,8 +81,8 @@ body {
   --text-1: {{colors.on_background.default.hex}}; /* other normally white text */
   --text-2: {{colors.on_surface.default.hex}}; /* headings and important text */
   --text-3: {{colors.on_surface_variant.default.hex}}; /* normal text */
-  --text-4: {{colors.outline.default.hex}}; /* icon buttons and channels */
-  --text-5: {{colors.outline_variant.default.hex}}; /* muted channels/chats and timestamps */
+  --text-4: color-mix(in srgb, {{colors.on_surface.default.hex}} 65%, {{colors.outline.default.hex}}); /* icon buttons and channels */
+  --text-5: color-mix(in srgb, {{colors.on_surface.default.hex}} 40%, {{colors.outline.default.hex}}); /* muted channels/chats and timestamps */
 
   /* background and dark colors */
   --bg-1: {{colors.surface_container_lowest.default.hex}}; /* dark buttons when clicked */
@@ -96,9 +96,9 @@ body {
 
   /* accent colors */
   --accent-1: {{colors.primary.default.hex}}; /* links and other accent text */
-  --accent-2: {{colors.primary_container.default.hex}}; /* small accent elements */
+  --accent-2: {{colors.primary.default.hex}}; /* small accent elements */
   --accent-3: {{colors.secondary.default.hex}}; /* accent buttons */
-  --accent-4: {{colors.on_secondary_container.default.hex}}; /* accent buttons when hovered */
+  --accent-4: color-mix(in srgb, {{colors.secondary.default.hex}} 80%, {{colors.on_surface.default.hex}}); /* accent buttons when hovered */
   --accent-5: {{colors.secondary.default.hex}}; /* accent buttons when clicked */
   --accent-new: {{colors.error.default.hex}}; /* stuff that's normally red like mute/deafen buttons */
 


### PR DESCRIPTION
This pull request resolves contrast and color mapping issues in the `discord-midnight` community template when rendered with different color palettes (e.g. Gruvbox Material).

##  Changes Made

### 1. Text Contrast Fix (`--text-4`, `--text-5`)
* **Issue**: The template previously mapped channel list text/icons (`--text-4`) and muted chats/timestamps (`--text-5`) directly to `colors.outline` and `colors.outline_variant`. In dark mode, these resolve to very dark grey/near-black border colors, making the channel list text and timestamps completely unreadable.
* **Fix**: Replaced outline mappings with custom HSL/RGB color mixes:
  * `--text-4` mixes 65% of the primary foreground (`on_surface`) with 35% outline, creating a legible cream-grey.
  * `--text-5` mixes 40% foreground with 60% outline, producing a clean, muted, yet readable gray.
* This logic matches the robust mixes implemented in other templates like `discord-system24` and works correctly for both light and dark shell modes.

### 2. Accent Mappings Fix (`--accent-2`, `--accent-4`)
* **Issue**: `--accent-2` (small accent elements, such as chosen/selected channel indicators) was mapped to a dark container background color (`primary_container`), which was invisible on dark backgrounds. `--accent-4` (hovered accent buttons) was mapped to a light text color (`on_secondary_container`), causing harsh brightness inconsistencies.
* **Fix**:
  * Re-mapped `--accent-2` to the primary accent color (`colors.primary`), keeping active channel selections highlighted in the theme's primary accent color (e.g. Gruvbox green).
  * Re-mapped `--accent-4` to a 80% secondary accent mix, creating a smooth and cohesive color shift on hover.

##  Type of Change
- [x] Bug fix

##  How Has This Been Tested?
- Generated and loaded the theme (`noctalia.theme.css`) locally on Vesktop using the Gruvbox Material palette (both dark and light modes).
- Verified that channel list names, icons, muted channels, active channels, and hovered buttons are fully legible and cohesive.


 