### PR TITLE
add velo launcher palette template

### DIFF
--- a/velo/apply.sh
+++ b/velo/apply.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/velo"
+config_file="$config_dir/config"
+palette_name="current-noctalia-override"
+
+darkmode="true"
+[ "${1:-}" = "light" ] && darkmode="false"
+
+mkdir -p "$config_dir"
+
+if [ ! -f "$config_file" ]; then
+    printf 'palette = "%s"\ndarkmode = %s\n' "$palette_name" "$darkmode" > "$config_file"
+    exit 0
+fi
+
+if grep -q '^palette[[:space:]]*=' "$config_file"; then
+    sed -i 's|^palette[[:space:]]*=.*|palette = "'"$palette_name"'"|' "$config_file"
+else
+    printf 'palette = "%s"\n' "$palette_name" >> "$config_file"
+fi
+
+if grep -q '^darkmode[[:space:]]*=' "$config_file"; then
+    sed -i 's|^darkmode[[:space:]]*=.*|darkmode = '"$darkmode"'|' "$config_file"
+else
+    printf 'darkmode = %s\n' "$darkmode" >> "$config_file"
+fi

--- a/velo/palette.json
+++ b/velo/palette.json
@@ -1,0 +1,18 @@
+{
+  "dark": {
+    "surface": "{{colors.surface.dark.hex}}",
+    "onSurface": "{{colors.on_surface.dark.hex}}",
+    "primary": "{{colors.primary.dark.hex}}",
+    "onPrimary": "{{colors.on_primary.dark.hex}}",
+    "secondary": "{{colors.secondary.dark.hex}}",
+    "outline": "{{colors.outline.dark.hex}}"
+  },
+  "light": {
+    "surface": "{{colors.surface.light.hex}}",
+    "onSurface": "{{colors.on_surface.light.hex}}",
+    "primary": "{{colors.primary.light.hex}}",
+    "onPrimary": "{{colors.on_primary.light.hex}}",
+    "secondary": "{{colors.secondary.light.hex}}",
+    "outline": "{{colors.outline.light.hex}}"
+  }
+}

--- a/velo/template.toml
+++ b/velo/template.toml
@@ -1,0 +1,8 @@
+[catalog.velo]
+name = "velo"
+category = "launcher"
+
+[templates.velo]
+input_path = "palette.json"
+output_path = "$XDG_CONFIG_HOME/velo/palettes/current-noctalia-override.json"
+post_hook = "bash '{{ config_dir }}/apply.sh' {{ mode }}"


### PR DESCRIPTION
## Summary

Adds a community template for [velo](https://github.com/user/velo), a fast plugin-extensible launcher for Wayland (C fork of tofi). When enabled, noctalia keeps velo's palette in sync with the active noctalia theme.

## How it works

Three files in :

**** (template input) renders noctalia's six relevant color tokens (surface, onSurface, primary, onPrimary, secondary, outline) in velo's native JSON palette format with dark and light variants. Written to .

**`apply.sh`** (post-hook) runs on every theme apply and:
1. Sets `palette = "current-noctalia-override"` in `~/.config/velo/config` (rewrites existing line, appends if missing, creates file if absent)
2. Sets `darkmode = true|false` to match noctalia's current mode

The rest of the config file is preserved. Same `sed` rewrite pattern velo's own theme-switch plugin uses.

**`template.toml`** registers the template under category `launcher`.

## Design notes

- Only writes one override palette file (`current-noctalia-override.json`); velo's vendored palettes are untouched
- No runtime signal: velo reads its config at startup, so the theme applies on next launch
- Uses velo's unprefixed key form (matches how velo's own palettes are authored; the m-prefixed form also works)
- velo's palette loader is lenient: accepts both unprefixed (`primary`) and noctalia m-prefixed (`mPrimary`) keys, and ignores unknown keys