### PR TITLE
add: Spicetify Colorful template

### DIFF
--- a/spicetify/README.MD
+++ b/spicetify/README.MD
@@ -1,0 +1,48 @@
+# Spicetify — Colorful
+
+A Noctalia v5 color template for the [Colorful](https://github.com/sanoojes/spicetify-colorful) Spicetify theme.
+
+Generates Colorful's `color.ini` from your active Noctalia palette and reapplies
+Spicetify automatically whenever your theme changes.
+
+## Requirements
+
+- [Spicetify](https://spicetify.app/docs/getting-started) installed and working
+- The **[Colorful](https://github.com/sanoojes/spicetify-colorful)** Spicetify theme installed at `~/.config/spicetify/Themes/Colorful`
+
+## What it does
+
+- `spicetify_colorful.ini` — maps Noctalia's palette to Colorful's `color.ini` keys.
+- `template.toml` — tells Noctalia where to write the generated file (`$XDG_CONFIG_HOME/spicetify/Themes/Colorful/color.ini`) and what to run afterward.
+- `apply.sh` — runs `spicetify apply -q --no-restart` so Spotify picks up the new colors without a manual step.
+
+## Manual Installation
+
+1. Add this block to your `config.toml`:
+
+   ```toml
+   [theme.templates.user.spicetify]
+   input_path = "spicetify_colorful.ini"
+   output_path = "$XDG_CONFIG_HOME/spicetify/Themes/Colorful/color.ini"
+   post_hook = "spicetify apply -q --no-restart"
+   ```
+
+2. Place `spicetify_colorful.ini` in the same directory as your `config.toml`, since `input_path` is resolved relative to it.
+
+## Post-installation
+
+To apply the theme run the commands below:
+
+```sh
+spicetify config current_theme Colorful
+spicetify config color_scheme noctalia
+spicetify apply
+```
+
+## Notes
+
+- `apply.sh` runs `spicetify apply --no-restart`, so Spotify won't be force-closed.
+  If the theme is already applied, hot-reload it with `Ctrl+Shift+R` instead.
+- This template is limited to color values only. Any CSS inconsistencies,
+  layout issues, or other formatting concerns are the responsibility of the
+  Colorful theme itself and should be reported upstream.

--- a/spicetify/README.MD
+++ b/spicetify/README.MD
@@ -2,13 +2,12 @@
 
 A Noctalia v5 color template for the [Colorful](https://github.com/sanoojes/spicetify-colorful) Spicetify theme.
 
-Generates Colorful's `color.ini` from your active Noctalia palette and reapplies
-Spicetify automatically whenever your theme changes.
+Generates Colorful's `color.ini` from your active Noctalia palette and reapplies Spicetify automatically whenever your theme changes.
 
 ## Requirements
 
 - [Spicetify](https://spicetify.app/docs/getting-started) installed and working
-- The **[Colorful](https://github.com/sanoojes/spicetify-colorful)** Spicetify theme installed at `~/.config/spicetify/Themes/Colorful`
+- The **[Colorful](https://github.com/sanoojes/spicetify-colorful)** Spicetify theme **MANUALLY** installed at `~/.config/spicetify/Themes/Colorful`
 
 ## What it does
 
@@ -34,8 +33,8 @@ Spicetify automatically whenever your theme changes.
 To apply the theme run the commands below:
 
 ```sh
-spicetify config current_theme Colorful
-spicetify config color_scheme noctalia
+spicetify config current_theme Colorful color_scheme noctalia
+spicetify config inject_css 1 replace_colors 1 overwrite_assets 1 inject_theme_js 1
 spicetify apply
 ```
 

--- a/spicetify/spicetify_colorful.ini
+++ b/spicetify/spicetify_colorful.ini
@@ -1,0 +1,18 @@
+[noctalia]
+text               = {{colors.on_surface.default.hex_stripped}}
+subtext            = {{colors.on_surface_variant.default.hex_stripped}}
+main               = {{colors.surface_variant.default.hex_stripped}}
+highlight          = {{colors.on_surface_variant.default.hex_stripped}}
+misc               = {{colors.outline.default.hex_stripped}}
+notification       = {{colors.tertiary.default.hex_stripped}}
+notification-error = {{colors.error.default.hex_stripped}}
+shadow             = {{colors.shadow.default.hex_stripped}}
+card               = {{colors.hover.default.hex_stripped}}
+player             = {{colors.surface_variant.default.hex_stripped}}
+sidebar            = {{colors.surface.default.hex_stripped}}
+main-elevated      = {{colors.surface_container_highest.default.hex_stripped}}
+selected-row       = {{colors.on_surface_variant.default.hex_stripped}}
+button             = {{colors.primary.default.hex_stripped}}
+button-active      = {{colors.primary.default.hex_stripped}}
+button-disabled    = {{colors.outline.default.hex_stripped}}
+

--- a/spicetify/template.toml
+++ b/spicetify/template.toml
@@ -6,3 +6,8 @@ category = "audio"
 input_path = "spicetify.ini"
 output_path = "$XDG_CONFIG_HOME/spicetify/Themes/Comfy/color.ini"
 post_hook = "bash '{{ config_dir }}/apply.sh'"
+
+[templates.spicetify_colorful]
+input_path = "spicetify_colorful.ini"
+output_path = "$XDG_CONFIG_HOME/spicetify/Themes/Colorful/color.ini"
+post_hook = "bash '{{ config_dir }}/apply.sh'"


### PR DESCRIPTION
Adds a Noctalia v5 color template for the Colorful Spicetify theme (https://github.com/sanoojes/spicetify-colorful), placed alongside the existing Comfy template under `spicetify/`.

- `spicetify/template.toml` — added `templates.spicetify_colorful` entry
- `spicetify/spicetify_colorful.ini` — color mapping
- `spicetify/README.md` — install/usage docs

Tested locally on
- CachyOS
- noctalia v5.0.0 (v5.0.0-beta2-48-g4529cd3d65e6)
- spicetify 2.44.0
- spotify version 1.2.92.147.g5b8f9367