### PR TITLE
feat(zen-browser): auto-detect profiles and enable custom CSS via user.js

### DIFF
--- a/zen-browser/apply.sh
+++ b/zen-browser/apply.sh
@@ -7,20 +7,33 @@ css_content="$cache_dir/noctalia/zen-browser/zen-userContent.css"
 line_chrome="@import \"$css_chrome\";"
 line_content="@import \"$css_content\";"
 
-find "${XDG_CONFIG_HOME:-$HOME/.config}/zen" "$HOME/.zen" -mindepth 2 -maxdepth 2 -type d -name chrome -print0 2>/dev/null |
-    while IFS= read -r -d '' dir; do
-        user_chrome="$dir/userChrome.css"
-        user_content="$dir/userContent.css"
-        mkdir -p "$dir"
-        touch "$user_chrome" "$user_content"
+find "${XDG_CONFIG_HOME:-$HOME/.config}/zen" "$HOME/.zen" -mindepth 2 -maxdepth 2 -type f -name "prefs.js" -print0 2>/dev/null |
+    while IFS= read -r -d '' prefs_file; do
+        profile_dir=$(dirname "$prefs_file")
+        chrome_dir="$profile_dir/chrome"
+        user_chrome="$chrome_dir/userChrome.css"
+        user_content="$chrome_dir/userContent.css"
+        user_js="$profile_dir/user.js"
+
+        mkdir -p "$chrome_dir"
+        touch "$user_chrome" "$user_content" "$user_js"
+
         sed -i '/zen-browser\/zen-userChrome\.css/d' "$user_chrome"
         sed -i '/zen-browser\/zen-userContent\.css/d' "$user_content"
+
         if ! grep -Fq "$line_chrome" "$user_chrome"; then
             [ -s "$user_chrome" ] && [ -n "$(tail -c1 "$user_chrome")" ] && echo >>"$user_chrome"
             printf '%s\n' "$line_chrome" >>"$user_chrome"
         fi
+
         if ! grep -Fq "$line_content" "$user_content"; then
             [ -s "$user_content" ] && [ -n "$(tail -c1 "$user_content")" ] && echo >>"$user_content"
             printf '%s\n' "$line_content" >>"$user_content"
         fi
+
+        sed -i '/toolkit\.legacyUserProfileCustomizations\.stylesheets/d' "$user_js"
+        sed -i '/devtools\.chrome\.enabled/d' "$user_js"
+        printf '%s\n' \
+            'user_pref("devtools.chrome.enabled", true);' \
+            'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);' >>"$user_js"
     done


### PR DESCRIPTION
## Template

- **App:** Zen Browser
- **Template id (directory):** `zen-browser`
- [ ] New template
- [x] Update to an existing template

## What it themes

- Renders Zen Browser chrome styles through `userChrome.css` and `userContent.css`
- Enables the required profile prefs through `user.js` so the theme is applied automatically

## Testing

- **App version tested:** <!-- add your Zen version here -->
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- Add screenshot(s) of Zen Browser with the theme applied -->

## Hooks

- **What the hook does:** Detects Zen profiles via `prefs.js`, creates the profile `chrome/` directory and CSS files if needed, adds the Noctalia `@import` lines, and writes required prefs to `user.js`
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [ ] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `audio`, `browser`, `compositor`, `editor`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.