### PR TITLE
feat(siyuan): init theme

### DIFF
--- a/siyuan/README.md
+++ b/siyuan/README.md
@@ -1,0 +1,16 @@
+# SiYuan — Noctalia Community Template
+
+Applies Noctalia's palette to [SiYuan](https://github.com/siyuan-note/siyuan) as a CSS variable override.
+
+## Requirements
+
+- SiYuan installed in home directory (any of `~/SiYuan` `~/Documents/SiYuan` `~/.siyuan/`)
+- `noctalia-siyaun` Theme installed from SiYuan marketplace
+
+## Notes
+
+- SiYuan automatically reloads theme on css change, so no need to restart app
+- This template works on three default installation paths:
+  - `~/SiYuan`
+  - `~/Documents/SiYuan`
+  - `~/.siyuan`

--- a/siyuan/siyuan.css
+++ b/siyuan/siyuan.css
@@ -1,0 +1,452 @@
+:root[data-theme-mode="light"] {
+    /* 主色 */
+    --b3-theme-primary: {{colors.primary.light.hex}};
+    --b3-theme-primary-light: {{ colors.primary.light.rgba | set_alpha 0.54 }};
+    --b3-theme-primary-lighter: {{ colors.primary.light.rgba | set_alpha 0.38 }};
+    --b3-theme-primary-lightest: {{ colors.primary.light.rgba | set_alpha 0.12 }};
+    --b3-theme-secondary: {{colors.secondary.light.hex}};
+    --b3-theme-background: {{colors.background.light.hex}};
+    --b3-theme-background-light: {{colors.background.light.rgba | set_alpha 0.54}};
+    --b3-theme-surface: {{colors.surface.light.hex}};
+    --b3-theme-surface-light: {{colors.surface.light.rgba | set_alpha 0.54}};
+    --b3-theme-surface-lighter: {{colors.surface.light.rgba | set_alpha 0.38}};
+    --b3-theme-error: {{colors.error.light.hex}};
+    --b3-theme-success: #3dc200;
+
+    /* 文字颜色 */
+    --b3-theme-on-primary: {{colors.on_primary.light.hex}};
+    --b3-theme-on-secondary: {{colors.on_secondary.light.hex}};
+    --b3-theme-on-background: {{colors.on_background.light.hex}};
+    --b3-theme-on-surface: {{colors.on_surface.light.hex}};
+    --b3-theme-on-surface-light: {{colors.on_surface.light.rgba | set_alpha 0.68 }};
+    --b3-theme-on-error: {{colors.on_error.light.hex}};
+
+    /* 字体 */
+    /* "Segoe UI" 和 Noto-COLRv1-2.047 冲突，故移除 */
+    --b3-font-family: "Emojis Additional", "Emojis Reset", BlinkMacSystemFont, Helvetica, "Luxi Sans", "DejaVu Sans", arial, sans-serif, emojis;
+    --b3-font-family-protyle: var(--b3-font-family);
+    --b3-font-family-code: "Emojis Additional", "Emojis Reset", "JetBrainsMono-Regular", mononoki, Consolas, "Liberation Mono", var(--b3-font-family);
+    --b3-font-family-graph: arial;
+    --b3-font-family-emoji: "Emojis Additional", emojis;
+    --b3-font-family-math: KaTeX_Math;
+    --b3-font-family-kbd: var(--b3-font-family-protyle);
+    --b3-font-size: 14px;
+
+    /* 顶部工具栏 */
+    --b3-toolbar-background: var(--b3-theme-surface);
+    --b3-toolbar-blur-background: #fcfcfc;
+    --b3-toolbar-color: var(--b3-theme-on-surface);
+    --b3-toolbar-hover: var(--b3-theme-background-light);
+    --b3-toolbar-left-mac: 74px;
+
+    /* 线条 */
+    --b3-border-color: var(--b3-theme-surface-lighter);
+    --b3-border-radius: 6px;
+    --b3-border-radius-s: 3px;
+    --b3-border-radius-b: 12px;
+
+    /* 滚动条 */
+    --b3-scroll-color: rgba(0, 0, 0, .2);
+
+    /* 列表 */
+    --b3-list-hover: rgba(0, 0, 0, .075);
+    --b3-list-icon-hover: rgba(33, 34, 36, .1);
+
+    /* 菜单 */
+    --b3-menu-background: var(--b3-theme-surface);
+
+    /* 提示 */
+    --b3-tooltips-background: #312f35;
+    --b3-tooltips-color: var(--b3-theme-background-light);
+    --b3-tooltips-second-color: #7d7c7a;
+    --b3-tooltips-shadow: 0 2px 8px rgba(0, 0, 0, .1);
+
+    /* 为空提示 */
+    --b3-empty-color: var(--b3-theme-on-surface-light);
+
+    /* 遮罩 */
+    --b3-mask-background: rgba(220, 220, 220, .4);
+
+    /* 卡片背景 */
+    --b3-card-error-color: {{colors.on_error_container.light.hex}};
+    --b3-card-error-background: {{colors.error_container.light.hex}};
+    --b3-card-warning-color: #b16700;
+    --b3-card-warning-background: #ffe8c8;
+    --b3-card-info-color: #005599;
+    --b3-card-info-background: #d6eaf9;
+    --b3-card-success-color: #008606;
+    --b3-card-success-background: #d7eed8;
+
+    /* 自定义文字 */
+    --b3-font-color1: var(--b3-card-error-color);
+    --b3-font-color2: var(--b3-card-warning-color);
+    --b3-font-color3: var(--b3-card-info-color);
+    --b3-font-color4: var(--b3-card-success-color);
+    --b3-font-color5: var(--b3-theme-on-surface);
+    --b3-font-color6: var(--b3-theme-primary);
+    --b3-font-color7: var(--b3-theme-secondary);
+    --b3-font-color8: var(--b3-theme-error);
+    --b3-font-color9: #f5539e;
+    --b3-font-color10: #00cdcd;
+    --b3-font-color11: #00b853;
+    --b3-font-color12: #9e9700;
+    --b3-font-color13: var(--b3-theme-background);
+    --b3-font-background1: var(--b3-card-error-background);
+    --b3-font-background2: var(--b3-card-warning-background);
+    --b3-font-background3: var(--b3-card-info-background);
+    --b3-font-background4: var(--b3-card-success-background);
+    --b3-font-background5: #e2e3e4;
+    --b3-font-background6: #acd0fc;
+    --b3-font-background7: #fddaab;
+    --b3-font-background8: #ffb0a9;
+    --b3-font-background9: #fdbfff;
+    --b3-font-background10: #b1ffff;
+    --b3-font-background11: #affad1;
+    --b3-font-background12: #fff88f;
+    --b3-font-background13: var(--b3-theme-on-background);
+
+    /* 动画效果 */
+    --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-width-transition: width .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-color-transition: color .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-background-transition: background 20ms ease-in 0s;
+
+    /* 高亮 */
+    --b3-highlight-color: #222;
+    --b3-highlight-background: #ffff00;
+    --b3-highlight-current-background: #ff9632;
+
+    /* 下拉菜单 */
+    --b3-select-background: url("data:image/svg+xml;utf8,<svg fill='rgba(95, 99, 104, .68)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>") no-repeat right 2px center var(--b3-theme-background);
+
+    /* switch */
+    --b3-switch-background: #e1e3e1;
+    --b3-switch-border: var(--b3-theme-on-surface-light);
+    --b3-switch-hover: rgba(31, 31, 31, 0.06);
+    --b3-switch-checked: #fff;
+    --b3-switch-checked-background: var(--b3-theme-primary);
+    --b3-switch-checked-hover: #d3e3fd;
+    --b3-switch-checked-hover2: rgba(31, 31, 31, .06);
+
+    /* 阴影 */
+    --b3-point-shadow: 0 0 1px 0 rgba(0, 0, 0, .1), 0 0 2px 0 rgba(0, 0, 0, .2);
+    --b3-dialog-shadow: 0 8px 24px rgba(0, 0, 0, .2);
+    --b3-button-shadow: 0 1px 2px 0 rgb(0 0 0 / .3), 0 1px 3px 1px rgb(0 0 0 /.15);
+    --b3-button-active-shadow: 0 2px 3px 1px rgb(0 0 0 / .3), 0 2px 4px 2px rgb(0 0 0 /.15);
+
+    /* 图表颜色 */
+    --b3-graph-p-point: #076f7e;
+    --b3-graph-heading-point: #8250df;
+    --b3-graph-math-point: #80FFA5;
+    --b3-graph-code-point: #00DDFF;
+    --b3-graph-table-point: {{colors.primary.light.hex}};
+    --b3-graph-list-point: #FF0087;
+    --b3-graph-todo-point: #FFBF00;
+    --b3-graph-olist-point: #b3005f;
+    --b3-graph-listitem-point: #f65b00;
+    --b3-graph-bq-point: #8d48e3;
+    --b3-graph-callout-point: var(--b3-theme-success);
+    --b3-graph-super-point: #dd79ff;
+    --b3-graph-doc-point: #202124;
+    --b3-graph-tag-point: #dbf32f;
+    --b3-graph-asset-point: #05c091;
+    --b3-graph-line: #5f6368;
+    --b3-graph-ref-line: #d23f31;
+    --b3-graph-tag-line: #5f6b06;
+    --b3-graph-tag-tag-line: #dbf32f;
+    --b3-graph-asset-line: #037457;
+    --b3-graph-hl-point: #f3a92f;
+    --b3-graph-hl-line: {{colors.primary.light.hex}};
+
+    /* 代码片段背景 */
+    --b3-protyle-code-background: rgba(27, 31, 35, .05);
+
+    /* 所见即所得行内元素颜色 */
+    --b3-protyle-inline-strong-color: inherit;
+    --b3-protyle-inline-em-color: inherit;
+    --b3-protyle-inline-u-color: inherit;
+    --b3-protyle-inline-s-color: inherit;
+    --b3-protyle-inline-link-color: {{colors.primary.light.hex}};
+    --b3-protyle-inline-mark-background: rgb(252, 212, 126);
+    --b3-protyle-inline-mark-color: #202124;
+    --b3-protyle-inline-tag-color: #5f6368;
+    --b3-protyle-inline-blockref-color: #8957e5;
+    --b3-protyle-inline-fileref-color: #21862e;
+
+    /* PDF */
+    --b3-pdf-selection: #d0e9c8;
+    --sidebar-width: 200px;
+    --b3-pdf-offset: 0;
+    --b3-pdf-background1: var(--b3-theme-error);
+    --b3-pdf-background2: #f5822e;
+    --b3-pdf-background3: #FACA5A;
+    --b3-pdf-background4: #7CC868;
+    --b3-pdf-background5: #FC5C88;
+    --b3-pdf-background6: #69B0F2;
+    --b3-pdf-background7: #C885DA;
+    --b3-pdf-dark: #212224;
+
+    /* callout */
+    --b3-callout-note: var(--b3-theme-primary);
+    --b3-callout-tip: var(--b3-theme-success);
+    --b3-callout-caution: var(--b3-theme-error);
+    --b3-callout-important: var(--b3-protyle-inline-blockref-color);
+    --b3-callout-warning: var(--b3-highlight-current-background);
+
+    /* 表格 */
+    --b3-table-even-background: rgba(0, 0, 0, .02);
+
+    /* 数据库 */
+    --b3-av-gallery-shadow: rgba(0, 0, 0, 0.04) 0px 2px 4px 0px, var(--b3-border-color) 0px 0px 0px 1px;
+
+    /* 嵌入块 */
+    --b3-embed-background: transparent;
+
+    /* 引述块 */
+    --b3-bq-background: transparent;
+
+    /* 父块颜色 */
+    --b3-parent-background: var(--b3-theme-background);
+
+    /* https://github.com/siyuan-note/siyuan/issues/6440 */
+    .protyle-action--order::after {
+        mix-blend-mode: multiply;
+    }
+
+    .b3-typography .code-block, .protyle-wysiwyg .code-block {
+        background-color: rgba(27, 31, 35, .05);
+    }
+}
+
+:root[data-theme-mode="dark"] {
+    /* 主色 */
+    --b3-theme-primary: {{colors.primary.dark.hex}};
+    --b3-theme-primary-light: {{ colors.primary.dark.rgba | set_alpha 0.54 }};
+    --b3-theme-primary-lighter: {{ colors.primary.dark.rgba | set_alpha 0.38 }};
+    --b3-theme-primary-lightest: {{ colors.primary.dark.rgba | set_alpha 0.12 }};
+    --b3-theme-secondary: {{colors.secondary.dark.hex}};
+    --b3-theme-background: {{colors.background.dark.hex}};
+    --b3-theme-background-light: {{colors.background.dark.rgba | set_alpha 0.54}};
+    --b3-theme-surface: {{colors.surface.dark.hex}};
+    --b3-theme-surface-light: {{colors.surface.dark.rgba | set_alpha 0.54}};
+    --b3-theme-surface-lighter: {{colors.surface.dark.rgba | set_alpha 0.38}};
+    --b3-theme-error: {{colors.error.dark.hex}};
+    --b3-theme-success: #65b84d;
+
+    /* 文字颜色 */
+    --b3-theme-on-primary: {{colors.on_primary.dark.hex}};
+    --b3-theme-on-secondary: {{colors.on_secondary.dark.hex}};
+    --b3-theme-on-background: {{colors.on_background.dark.hex}};
+    --b3-theme-on-surface: {{colors.on_surface.dark.hex}};
+    --b3-theme-on-surface-light: {{colors.on_surface.dark.rgba | set_alpha 0.68 }};
+    --b3-theme-on-error: {{colors.on_error.dark.hex}};
+
+    /* 字体 */
+    --b3-font-family: "Emojis Additional", "Emojis Reset", BlinkMacSystemFont, Helvetica, "Luxi Sans", "DejaVu Sans", arial, sans-serif, emojis;
+    --b3-font-family-protyle: var(--b3-font-family);
+    --b3-font-family-code: "Emojis Additional", "Emojis Reset", "JetBrainsMono-Regular", mononoki, Consolas, "Liberation Mono", var(--b3-font-family);
+    --b3-font-family-graph: arial;
+    --b3-font-family-emoji: "Emojis Additional", emojis;
+    --b3-font-family-math: KaTeX_Math;
+    --b3-font-family-kbd: var(--b3-font-family-protyle);
+    --b3-font-size: 14px;
+
+    /* 顶部工具栏 */
+    --b3-toolbar-background: var(--b3-theme-surface);
+    --b3-toolbar-blur-background: var(--b3-border-color);
+    --b3-toolbar-color: var(--b3-theme-on-surface);
+    --b3-toolbar-hover: var(--b3-theme-background-light);
+    --b3-toolbar-left-mac: 74px;
+
+    /* 线条 */
+    --b3-border-color: #363636;
+    --b3-border-radius: 6px;
+    --b3-border-radius-s: 3px;
+    --b3-border-radius-b: 12px;
+
+    /* 滚动条 */
+    --b3-scroll-color: rgba(230, 230, 230, .2);
+
+    /* 列表 */
+    --b3-list-hover: rgba(255, 255, 255, .075);
+    --b3-list-icon-hover: rgba(201, 209, 217, .1);
+
+    /* 菜单 */
+    --b3-menu-background: var(--b3-theme-surface);
+
+    /* 提示 */
+    --b3-tooltips-background: #030303;
+    --b3-tooltips-color: var(--b3-theme-on-surface-light);
+    --b3-tooltips-second-color: #7d7c7a;
+    --b3-tooltips-shadow: 0 2px 8px rgba(0, 0, 0, .3);
+
+    /* 为空提示 */
+    --b3-empty-color: var(--b3-theme-on-surface);
+
+    /* 遮罩 */
+    --b3-mask-background: rgba(10, 10, 10, .4);
+
+    /* 卡片背景 */
+    --b3-card-error-color: {{colors.on_error_container.dark.hex}};
+    --b3-card-error-background: {{colors.error_container.dark.hex}};
+    --b3-card-warning-color: rgb(255, 213, 153);
+    --b3-card-warning-background: #554636;
+    --b3-card-info-color: rgb(166, 213, 250);
+    --b3-card-info-background: #28405c;
+    --b3-card-success-color: rgb(183, 223, 185);
+    --b3-card-success-background: #425347;
+
+    /* 自定义文字 */
+    --b3-font-color1: var(--b3-card-error-color);
+    --b3-font-color2: var(--b3-card-warning-color);
+    --b3-font-color3: var(--b3-card-info-color);
+    --b3-font-color4: var(--b3-card-success-color);
+    --b3-font-color5: var(--b3-theme-on-surface);
+    --b3-font-color6: var(--b3-theme-primary);
+    --b3-font-color7: var(--b3-theme-secondary);
+    --b3-font-color8: var(--b3-theme-error);
+    --b3-font-color9: #f5539e;
+    --b3-font-color10: #00eeff;
+    --b3-font-color11: #74ff00;
+    --b3-font-color12: #fff200;
+    --b3-font-color13: var(--b3-theme-background);
+    --b3-font-background1: var(--b3-card-error-background);
+    --b3-font-background2: var(--b3-card-warning-background);
+    --b3-font-background3: var(--b3-card-info-background);
+    --b3-font-background4: var(--b3-card-success-background);
+    --b3-font-background5: #4c5257;
+    --b3-font-background6: #08296c;
+    --b3-font-background7: #593905;
+    --b3-font-background8: #541812;
+    --b3-font-background9: #843473;
+    --b3-font-background10: #329096;
+    --b3-font-background11: #568b2a;
+    --b3-font-background12: #8d8829;
+    --b3-font-background13: var(--b3-theme-on-background);
+
+    /* 动画效果 */
+    --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-width-transition: width .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-color-transition: color .2s cubic-bezier(0, 0, .2, 1) 0ms;
+    --b3-background-transition: background 20ms ease-in 0s;
+
+    /* 高亮 */
+    --b3-highlight-color: #222;
+    --b3-highlight-background: #ffff00;
+    --b3-highlight-current-background: #ff9632;
+
+    /* 下拉菜单 */
+    --b3-select-background: url("data:image/svg+xml;utf8,<svg fill='rgba(154, 160, 166, .68)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>") no-repeat right 2px center var(--b3-theme-background);
+
+    /* switch */
+    --b3-switch-background: #444746;
+    --b3-switch-border: var(--b3-theme-on-surface-light);
+    --b3-switch-hover: rgba(253, 252, 251, .10);
+    --b3-switch-checked: var(--b3-theme-primary);
+    --b3-switch-checked-background: #a8c7fa;
+    --b3-switch-checked-hover: var(--b3-theme-primary);
+    --b3-switch-checked-hover2: rgba(253, 252, 251, .10);
+
+    /* 阴影 */
+    --b3-point-shadow: inset 0 .5px .5px .5px rgba(255, 255, 255, .09), 0 3px 6px rgba(0, 0, 0, .04), 0 0 0 0 transparent;
+    --b3-dialog-shadow: 0 8px 24px #010409;
+    --b3-button-shadow: 0 1px 2px 0 rgb(0 0 0 / .3), 0 1px 3px 1px rgb(255 255 255 /.15);
+    --b3-button-active-shadow: 0 2px 3px 1px rgb(0 0 0 / .3), 0 2px 4px 2px rgb(255 255 255 /.15);
+
+    /* 图表颜色 */
+    --b3-graph-p-point: #076f7e;
+    --b3-graph-heading-point: hsl(254, 80%, 74.8%);
+    --b3-graph-math-point: #80FFA5;
+    --b3-graph-code-point: #00DDFF;
+    --b3-graph-table-point: {{colors.primary.dark.hex}};
+    --b3-graph-list-point: #FF0087;
+    --b3-graph-todo-point: #FFBF00;
+    --b3-graph-olist-point: #b3005f;
+    --b3-graph-listitem-point: #f65b00;
+    --b3-graph-bq-point: #8d48e3;
+    --b3-graph-callout-point: var(--b3-theme-success);
+    --b3-graph-super-point: #dd79ff;
+    --b3-graph-doc-point: #e8eaed;
+    --b3-graph-tag-point: #dbf32f;
+    --b3-graph-asset-point: #05c091;
+    --b3-graph-line: #9aa0a6;
+    --b3-graph-ref-line: #d23f31;
+    --b3-graph-tag-line: #5f6b06;
+    --b3-graph-tag-tag-line: #dbf32f;
+    --b3-graph-asset-line: #037457;
+    --b3-graph-hl-point: #f3a92f;
+    --b3-graph-hl-line: {{colors.primary.dark.hex}};
+
+    /* 代码片段背景 */
+    --b3-protyle-code-background: rgba(240, 246, 252, .15);
+
+    /* 所见即所得行内元素颜色 */
+    --b3-protyle-inline-strong-color: inherit;
+    --b3-protyle-inline-em-color: inherit;
+    --b3-protyle-inline-u-color: inherit;
+    --b3-protyle-inline-s-color: inherit;
+    --b3-protyle-inline-link-color: {{colors.primary.dark.hex}};
+    --b3-protyle-inline-mark-background: #b29100;
+    --b3-protyle-inline-mark-color: var(--b3-theme-on-background);
+    --b3-protyle-inline-tag-color: #9aa0a6;
+    --b3-protyle-inline-blockref-color: #8957e5;
+    --b3-protyle-inline-fileref-color: var(--b3-theme-secondary);
+
+    /* PDF */
+    --b3-pdf-selection: #779170;
+    --sidebar-width: 200px;
+    --b3-pdf-offset: 0;
+    --b3-pdf-background1: var(--b3-theme-error);
+    --b3-pdf-background2: #f5822e;
+    --b3-pdf-background3: #FACA5A;
+    --b3-pdf-background4: #7CC868;
+    --b3-pdf-background5: #FC5C88;
+    --b3-pdf-background6: #69B0F2;
+    --b3-pdf-background7: #C885DA;
+    --b3-pdf-dark: #212224;
+
+    /* callout */
+    --b3-callout-note: var(--b3-theme-primary);
+    --b3-callout-tip: var(--b3-theme-success);
+    --b3-callout-caution: var(--b3-theme-error);
+    --b3-callout-important: var(--b3-protyle-inline-blockref-color);
+    --b3-callout-warning: var(--b3-highlight-current-background);
+
+    /* 表格 */
+    --b3-table-even-background: rgba(255, 255, 255, .03);
+
+    /* 数据库 */
+    --b3-av-gallery-shadow: rgba(0, 0, 0, 0.04) 0px 2px 4px 0px, var(--b3-border-color) 0px 0px 0px 1px;
+
+    /* 嵌入块 */
+    --b3-embed-background: transparent;
+
+    /* 引述块 */
+    --b3-bq-background: transparent;
+
+    /* 父块颜色 */
+    --b3-parent-background: var(--b3-theme-background);
+
+
+    /* https://github.com/siyuan-note/siyuan/issues/6440 */
+    .protyle-action--order::after {
+        mix-blend-mode: screen;
+    }
+
+    .b3-text-field::-webkit-calendar-picker-indicator {
+        filter: invert(1)
+    }
+}
+
+/* 微软字体斜体会被相邻背景遮挡，将 arial 放置其前 https://github.com/siyuan-note/siyuan/issues/11841 */
+:root:lang(zh_CN) {
+    --b3-font-family: "Emojis Additional", "Emojis Reset", BlinkMacSystemFont, Helvetica, "PingFang SC", "Luxi Sans", "DejaVu Sans", arial, "Microsoft Yahei", "Hiragino Sans GB", "Source Han Sans SC", sans-serif, emojis;
+}
+
+:root:lang(zh_CHT) {
+    --b3-font-family: "Emojis Additional", "Emojis Reset", BlinkMacSystemFont, Helvetica, "PingFang TC", "Luxi Sans", "DejaVu Sans", arial, "Microsoft JhengHei", "Hiragino Sans TC", "Source Han Sans TC", sans-serif, emojis;
+}
+
+:root:lang(ja_JP) {
+    --b3-font-family: "Emojis Additional", "Emojis Reset", BlinkMacSystemFont, Helvetica, "Luxi Sans", "DejaVu Sans", "Yu Gothic UI", arial, sans-serif, emojis;
+}

--- a/siyuan/template.toml
+++ b/siyuan/template.toml
@@ -1,6 +1,6 @@
 [catalog.siyuan]
 name = "Siyuan"
-category = "productivity"
+category = "misc"
 
 [templates.siyuan]
 input_path = "siyuan.css"

--- a/siyuan/template.toml
+++ b/siyuan/template.toml
@@ -1,0 +1,13 @@
+[catalog.siyuan]
+name = "Siyuan"
+category = "productivity"
+
+[templates.siyuan]
+input_path = "siyuan.css"
+output_path = [ "~/Documents/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+requires_path = "~/Documents/SiYuan"
+
+[templates.siyuan-home]
+input_path = "siyuan.css"
+output_path = [ "~/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+requires_path = "~/SiYuan"

--- a/siyuan/template.toml
+++ b/siyuan/template.toml
@@ -5,9 +5,14 @@ category = "productivity"
 [templates.siyuan]
 input_path = "siyuan.css"
 output_path = [ "~/Documents/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
-requires_path = "~/Documents/SiYuan"
+requires_path = "~/Documents/SiYuan/conf/appearance/themes/"
 
 [templates.siyuan-home]
 input_path = "siyuan.css"
 output_path = [ "~/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
-requires_path = "~/SiYuan"
+requires_path = "~/SiYuan/conf/appearance/themes/"
+
+[templates.siyuan-dot]
+input_path = "siyuan.css"
+output_path = [ "~/.siyuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+requires_path = "~/.siyuan/conf/appearance/themes/"

--- a/siyuan/template.toml
+++ b/siyuan/template.toml
@@ -4,15 +4,15 @@ category = "misc"
 
 [templates.siyuan]
 input_path = "siyuan.css"
-output_path = [ "~/Documents/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+output_path = "~/Documents/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css"
 requires_path = "~/Documents/SiYuan/conf/appearance/themes/"
 
 [templates.siyuan-home]
 input_path = "siyuan.css"
-output_path = [ "~/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+output_path = "~/SiYuan/conf/appearance/themes/noctalia-siyuan/theme.css"
 requires_path = "~/SiYuan/conf/appearance/themes/"
 
 [templates.siyuan-dot]
 input_path = "siyuan.css"
-output_path = [ "~/.siyuan/conf/appearance/themes/noctalia-siyuan/theme.css" ];
+output_path = "~/.siyuan/conf/appearance/themes/noctalia-siyuan/theme.css"
 requires_path = "~/.siyuan/conf/appearance/themes/"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** [SiYuan](https://github.com/siyuan-note/siyuan)
- **Template id (directory):** `siyuan`
- [X] New template
- [ ] Update to an existing template

## What it themes

Custom theme .css

## Notes

I created a Noctalia colored theme and uploaded it to siyuan's marketplace so this template can modify user's .css without overriding current theme
- [Theme repo](https://github.com/Gambled23/noctalia-siyuan)
- [SiYuan PR](https://github.com/siyuan-note/bazaar/pull/1906)
- [X] README.md included

## Testing

I added it as a user tempate and listed my templates with `noctalia theme --list-templates` before changing my theme

- **App version tested:** Siyuan v3.7.1
- [X] Applied a dark theme and confirmed the app picked it up
- [X] Applied a light theme and confirmed the app picked it up
- [X] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<img width="1916" height="1040" alt="image" src="https://github.com/user-attachments/assets/f8917771-ca51-49d9-b286-b6368cc7bba5" />
<img width="1912" height="1037" alt="image" src="https://github.com/user-attachments/assets/1dc06b90-bd5b-4377-a074-0ecce9612868" />


## Checklist

- [X] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [X] `category` is one of: `audio`, `browser`, `compositor`, `editor`, `launcher`, `system`, `terminal`, `misc`.
- [X] Every `input_path` names a file that exists in this directory.
- [X] No generated output or app-specific personal config is committed.
