### PR TITLE
exit gracefully if `user.js` is immutable (e.g., a `/nix/store` symlink)

### DIFF
--- a/zen-browser/apply.sh
+++ b/zen-browser/apply.sh
@@ -16,7 +16,7 @@ find "${XDG_CONFIG_HOME:-$HOME/.config}/zen" "$HOME/.zen" -mindepth 2 -maxdepth 
         user_js="$profile_dir/user.js"
 
         mkdir -p "$chrome_dir"
-        touch "$user_chrome" "$user_content" "$user_js"
+        touch "$user_chrome" "$user_content"
 
         sed -i '/zen-browser\/zen-userChrome\.css/d' "$user_chrome"
         sed -i '/zen-browser\/zen-userContent\.css/d' "$user_content"
@@ -31,9 +31,14 @@ find "${XDG_CONFIG_HOME:-$HOME/.config}/zen" "$HOME/.zen" -mindepth 2 -maxdepth 
             printf '%s\n' "$line_content" >>"$user_content"
         fi
 
-        sed -i '/toolkit\.legacyUserProfileCustomizations\.stylesheets/d' "$user_js"
-        sed -i '/devtools\.chrome\.enabled/d' "$user_js"
-        printf '%s\n' \
-            'user_pref("devtools.chrome.enabled", true);' \
-            'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);' >>"$user_js"
+        if { [ -e "$user_js" ] && [ -w "$user_js" ]; } || { [ ! -e "$user_js" ] && [ -w "$profile_dir" ]; }; then
+            touch "$user_js"
+            sed -i '/toolkit\.legacyUserProfileCustomizations\.stylesheets/d' "$user_js"
+            sed -i '/devtools\.chrome\.enabled/d' "$user_js"
+            printf '%s\n' \
+                'user_pref("devtools.chrome.enabled", true);' \
+                'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);' >>"$user_js"
+        else
+            echo "Skipping user.js (not writable): $user_js" >&2
+        fi
     done


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** Zen Browser <!-- e.g. Fuzzel -->
- **Template id (directory):** `zen-browser`
- [ ] New template
- [x] Update to an existing template

## What it themes

If `user.js` is immutable (say, for example, a symlink to a location in `/nix/store` on NixOS), the `apply.sh` script currently fails without modifying _any_ of the files. This change checks if `user.js` is writable, and acts on it only if it is.

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** Zen Browser 1.21.8b <!-- e.g. fuzzel 1.11.0 -->
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- The app running with the theme applied. Required. -->

<img width="2774" height="1834" alt="image" src="https://github.com/user-attachments/assets/aaaa32b8-fe53-483a-a86d-70530423564c" />

## Hooks

<!-- Skip this section if the template has no pre_hook or post_hook. -->

- **What the hook does:** <!-- e.g. rewrites `theme = "..."` in the app's config so it points at the rendered file -->
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `audio`, `browser`, `compositor`, `editor`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
