### PR TITLE
zen-browser: live dark/light mode switching via prefers-color-scheme

### DIFF
--- a/zen-browser/zen-userChrome.css
+++ b/zen-browser/zen-userChrome.css
@@ -1,18 +1,38 @@
-* {
-  --base:             {{colors.background.default.hex}};
-  --surface:          {{colors.surface_container_low.default.hex}};
-  --overlay:          {{colors.surface_container.default.hex}};
-	--hl_low:           {{colors.surface_container_high.default.hex}};
-	--hl_med:           {{colors.surface_container_highest.default.hex}};
-	--hl_high:          {{colors.surface_bright.default.hex}};
-	--outline:          {{colors.outline_variant.default.hex}};
-  --muted:            {{colors.outline.default.hex}};
-  --subtle:           {{colors.on_surface_variant.default.hex}};
-  --text:             {{colors.on_surface.default.hex}};
-  --primary:          {{colors.primary.default.hex}};
-  --secondary:        {{colors.secondary.default.hex}};
-	--tertiary:         {{colors.tertiary.default.hex}};
-	--error:            {{colors.error.default.hex}};
+@media (prefers-color-scheme: dark) {
+  * {
+    --base:             {{colors.background.dark.hex}};
+    --surface:          {{colors.surface_container_low.dark.hex}};
+    --overlay:          {{colors.surface_container.dark.hex}};
+    --hl_low:           {{colors.surface_container_high.dark.hex}};
+    --hl_med:           {{colors.surface_container_highest.dark.hex}};
+    --hl_high:          {{colors.surface_bright.dark.hex}};
+    --outline:          {{colors.outline_variant.dark.hex}};
+    --muted:            {{colors.outline.dark.hex}};
+    --subtle:           {{colors.on_surface_variant.dark.hex}};
+    --text:             {{colors.on_surface.dark.hex}};
+    --primary:          {{colors.primary.dark.hex}};
+    --secondary:        {{colors.secondary.dark.hex}};
+    --tertiary:         {{colors.tertiary.dark.hex}};
+    --error:            {{colors.error.dark.hex}};
+  }
+}
+@media (prefers-color-scheme: light) {
+  * {
+    --base:             {{colors.background.light.hex}};
+    --surface:          {{colors.surface_container_low.light.hex}};
+    --overlay:          {{colors.surface_container.light.hex}};
+    --hl_low:           {{colors.surface_container_high.light.hex}};
+    --hl_med:           {{colors.surface_container_highest.light.hex}};
+    --hl_high:          {{colors.surface_bright.light.hex}};
+    --outline:          {{colors.outline_variant.light.hex}};
+    --muted:            {{colors.outline.light.hex}};
+    --subtle:           {{colors.on_surface_variant.light.hex}};
+    --text:             {{colors.on_surface.light.hex}};
+    --primary:          {{colors.primary.light.hex}};
+    --secondary:        {{colors.secondary.light.hex}};
+    --tertiary:         {{colors.tertiary.light.hex}};
+    --error:            {{colors.error.light.hex}};
+  }
 }
 
 :root {

--- a/zen-browser/zen-userContent.css
+++ b/zen-browser/zen-userContent.css
@@ -1,18 +1,38 @@
-* {
-  --base:             {{colors.background.default.hex}};
-  --surface:          {{colors.surface_container_low.default.hex}};
-  --overlay:          {{colors.surface_container.default.hex}};
-	--hl_low:           {{colors.surface_container_high.default.hex}};
-	--hl_med:           {{colors.surface_container_highest.default.hex}};
-	--hl_high:          {{colors.surface_bright.default.hex}};
-	--outline:          {{colors.outline_variant.default.hex}};
-  --muted:            {{colors.outline.default.hex}};
-  --subtle:           {{colors.on_surface_variant.default.hex}};
-  --text:             {{colors.on_surface.default.hex}};
-	--primary:          {{colors.primary.default.hex}};
-  --secondary:        {{colors.secondary.default.hex}};
-	--tertiary:         {{colors.tertiary.default.hex}};
-	--error:            {{colors.error.default.hex}};
+@media (prefers-color-scheme: dark) {
+  * {
+    --base:             {{colors.background.dark.hex}};
+    --surface:          {{colors.surface_container_low.dark.hex}};
+    --overlay:          {{colors.surface_container.dark.hex}};
+    --hl_low:           {{colors.surface_container_high.dark.hex}};
+    --hl_med:           {{colors.surface_container_highest.dark.hex}};
+    --hl_high:          {{colors.surface_bright.dark.hex}};
+    --outline:          {{colors.outline_variant.dark.hex}};
+    --muted:            {{colors.outline.dark.hex}};
+    --subtle:           {{colors.on_surface_variant.dark.hex}};
+    --text:             {{colors.on_surface.dark.hex}};
+    --primary:          {{colors.primary.dark.hex}};
+    --secondary:        {{colors.secondary.dark.hex}};
+    --tertiary:         {{colors.tertiary.dark.hex}};
+    --error:            {{colors.error.dark.hex}};
+  }
+}
+@media (prefers-color-scheme: light) {
+  * {
+    --base:             {{colors.background.light.hex}};
+    --surface:          {{colors.surface_container_low.light.hex}};
+    --overlay:          {{colors.surface_container.light.hex}};
+    --hl_low:           {{colors.surface_container_high.light.hex}};
+    --hl_med:           {{colors.surface_container_highest.light.hex}};
+    --hl_high:          {{colors.surface_bright.light.hex}};
+    --outline:          {{colors.outline_variant.light.hex}};
+    --muted:            {{colors.outline.light.hex}};
+    --subtle:           {{colors.on_surface_variant.light.hex}};
+    --text:             {{colors.on_surface.light.hex}};
+    --primary:          {{colors.primary.light.hex}};
+    --secondary:        {{colors.secondary.light.hex}};
+    --tertiary:         {{colors.tertiary.light.hex}};
+    --error:            {{colors.error.light.hex}};
+  }
 }
 
 /* Common variables affecting all pages */


### PR DESCRIPTION
## Summary

- Replace single `.default.hex` color variable block with two `@media (prefers-color-scheme: dark/light)` blocks using `.dark.hex` and `.light.hex` values
- Zen Browser (like Firefox) only reads `userChrome.css` at startup and never reloads it on disk changes. Previously, toggling dark/light mode in Noctalia re-rendered the CSS file but Zen wouldn't pick up the new colors without a restart
- With this change, both dark and light color values are baked into the CSS at render time, and Zen responds to the system `prefers-color-scheme` preference live — no restart needed

## Changes

- `zen-userChrome.css`: variable definitions block (lines 1–16)
- `zen-userContent.css`: variable definitions block (lines 1–16)

All CSS selectors and `var()` references remain unchanged — only the variable definition strategy changed.

## Test plan

- [x] Apply template (toggle scheme or restart Noctalia to trigger re-render)
- [x] Restart Zen Browser once to load the new CSS structure
- [x] Toggle Noctalia dark → light: Zen toolbar, buttons, and content pages should update live
- [x] Toggle back light → dark: should also update live
- [x] Verify no visual regressions in dark mode vs. before this change
