### PR TITLE
fix(zen-browser): improve bookmark folder tree readability

### DIFF
--- a/zen-browser/zen-userChrome.css
+++ b/zen-browser/zen-userChrome.css
@@ -443,7 +443,7 @@ panel[type="autocomplete-richlistbox"],
 
 /* --- Bookmark Panel Folder Tree Styling --- */
 #editBMPanel_folderTree {
-  background-color: var(--subtle) !important;
+  background-color: var(--base) !important;
   background-image: none !important;
   color: var(--text) !important;
   border-radius: 8px !important;


### PR DESCRIPTION
The previous background color `--subtle` was too close to the text color, making
the bookmark tree difficult to read in some colorscheme (especially in dark mode). Switching to `--base`
provides adequate contrast.

zen: 1.21.8b
theme: Shien-dark
<img width="488" height="565" alt="screenshot_20260728_155432-region" src="https://github.com/user-attachments/assets/9173000f-8633-46d0-8c68-a3a7430be3bd" />
<img width="494" height="571" alt="screenshot_20260728_155605-region" src="https://github.com/user-attachments/assets/b0af2e0b-7808-4c0d-889c-97c921cae205" />
