### PR TITLE
feat: add driftwm community template

### DIFF
--- a/driftwm/apply.sh
+++ b/driftwm/apply.sh
@@ -1,0 +1,42 @@
+colors_file="${XDG_CACHE_HOME:-$HOME/.cache}/noctalia-driftwm-colors"
+driftwm_config="${XDG_CONFIG_HOME:-$HOME/.config}/driftwm/config.toml"
+
+if [ ! -f "$colors_file" ]; then
+    echo "noctalia-driftwm: colors file not found at $colors_file" >&2
+    exit 1
+fi
+
+bg_line=
+fg_line=
+border_line=
+border_focused_line=
+
+while IFS= read -r line; do
+    key="${line%% = *}"
+    case "$key" in
+        bg_color)              bg_line="$line" ;;
+        fg_color)              fg_line="$line" ;;
+        border_color)          border_line="$line" ;;
+        border_color_focused)  border_focused_line="$line" ;;
+    esac
+done < "$colors_file"
+
+sed_script=
+for def_line in "$bg_line" "$fg_line" "$border_line" "$border_focused_line"; do
+    [ -n "$def_line" ] || continue
+    k="${def_line%% = *}"
+    v="${def_line#* = }"
+    sed_script="${sed_script}s|^$k = .*|$k = $v|;"
+done
+
+if [ -z "$sed_script" ]; then
+    echo "noctalia-driftwm: no color values found in $colors_file" >&2
+    exit 1
+fi
+
+if [ ! -f "$driftwm_config" ]; then
+    echo "noctalia-driftwm: driftwm config not found at $driftwm_config" >&2
+    exit 1
+fi
+
+sed -i "$sed_script" "$driftwm_config"

--- a/driftwm/driftwm-colors
+++ b/driftwm/driftwm-colors
@@ -1,0 +1,4 @@
+bg_color = "{{colors.terminal_background.default.hex}}"
+fg_color = "{{colors.terminal_foreground.default.hex}}"
+border_color = "{{colors.terminal_normal_black.default.hex}}"
+border_color_focused = "{{colors.primary.default.hex}}"

--- a/driftwm/template.toml
+++ b/driftwm/template.toml
@@ -1,0 +1,8 @@
+[catalog.driftwm]
+name = "DriftWM"
+category = "compositor"
+
+[templates.driftwm]
+input_path = "driftwm-colors"
+output_path = "$XDG_CACHE_HOME/noctalia-driftwm-colors"
+post_hook = "bash '{{ config_dir }}/apply.sh'"


### PR DESCRIPTION
## Template

- **App:** DriftWM (compositor/window manager)
- **Template id (directory):** `driftwm`
- [x] New template
- [ ] Update to an existing template

## What it themes

Colors in `driftwm/config.toml`: `bg_color`, `fg_color`, `border_color`, `border_color_focused`.

## Testing

- **App version tested:** driftwm (HEAD)
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots
**Ayu theme**
<img width="1919" height="1079" alt="screenshot_20260729_042539-region" src="https://github.com/user-attachments/assets/14aa0901-41f3-4998-afc1-322f7ced9366" />

**TokyoNight theme**
<img width="1919" height="1079" alt="screenshot_20260729_042553-region" src="https://github.com/user-attachments/assets/f86479bb-b934-4936-abe8-fd5512423406" />

**Cyberpunk theme (community)**
<img width="1919" height="1079" alt="screenshot_20260729_042759-region" src="https://github.com/user-attachments/assets/9a0917c7-b1b2-49b2-89d8-bcfa904689dc" />

**Atuel Light (community)**. Note that the windows decorators are a part of GTK theme, not driftwm itself
<img width="1914" height="1079" alt="screenshot_20260729_043233-region" src="https://github.com/user-attachments/assets/8ba23dbf-7850-4376-969b-2f4a1d989428" />

## Hooks

- **What the hook does:** Reads rendered colors from `$XDG_CACHE_HOME/noctalia-driftwm-colors`, applies them to `driftwm/config.toml` via `sed -i`.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.