### PR TITLE
fix(yazi): use theme colors for filetype rules

### DIFF
--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -152,16 +152,16 @@ title_error = { fg = "{{colors.error.default.hex}}" }
 
 rules = [
     # Images
-    { mime = "image/*", fg = "#94e2d5" },
+    { mime = "image/*", fg = "{{colors.primary_fixed_dim.default.hex}}" },
 
     # Media
-    { mime = "{audio,video}/*", fg = "#f9e2af" },
+    { mime = "{audio,video}/*", fg = "{{colors.tertiary_fixed_dim.default.hex}}" },
 
     # Archives
-    { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "#f5c2e7" },
+    { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "{{colors.secondary.default.hex}}" },
 
     # Documents
-    { mime = "application/{pdf,doc,rtf}", fg = "#a6e3a1" },
+    { mime = "application/{pdf,doc,rtf}", fg = "{{colors.tertiary.default.hex}}" },
 
     # Special files
     { mime = "*", is = "orphan", fg = "{{colors.on_error_container.default.hex}}", bg = "{{colors.error_container.default.hex}}" },


### PR DESCRIPTION
Replace hardcoded Catppuccin hex colors for images, media, archives, and documents with {{colors.*}} template variables, so they follow the user's Material You theme and stay readable on any background.

Closes #60