### PR TITLE
Add zellij template

### DIFF
--- a/zellij/template.toml
+++ b/zellij/template.toml
@@ -1,0 +1,8 @@
+[catalog.zellij]
+name = "Zellij"
+category = "misc"
+
+[templates.zellij]
+input_path = "zellij.kdl"
+output_path = "$XDG_CONFIG_HOME/zellij/themes/noctalia.kdl"
+# post_hook = "touch $XDG_CONFIG_HOME/zellij/config.kdl" # trigger config auto-reload

--- a/zellij/zellij.kdl
+++ b/zellij/zellij.kdl
@@ -1,0 +1,15 @@
+themes {
+  noctalia {
+    fg "{{colors.terminal_foreground.default.hex}}"
+    bg "{{colors.terminal_background.default.hex}}"
+    black "{{colors.terminal_normal_black.default.hex}}"
+    red "{{colors.terminal_normal_red.default.hex}}"
+    green "{{colors.terminal_normal_green.default.hex}}"
+    yellow "{{colors.terminal_normal_yellow.default.hex}}"
+    blue "{{colors.terminal_normal_blue.default.hex}}"
+    magenta "{{colors.terminal_normal_magenta.default.hex}}"
+    cyan "{{colors.terminal_normal_cyan.default.hex}}"
+    white "{{colors.terminal_normal_white.default.hex}}"
+    orange "{{colors.terminal_normal_red.default.hex | rotate_hue 30}}"
+  }
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** Zellij
- **Template id (directory):** zellij
- [x] New template
- [ ] Update to an existing template

## What it themes

<!-- Which config file(s) of the app get rendered, and what the user sees change. -->

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** zellij 0.44.3
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- The app running with the theme applied. Required. -->
todo

## Hooks

<!-- Skip this section if the template has no pre_hook or post_hook. -->

The hook I added works on non-RO configurations (ie it doesn't work on nix, idk for stow). I haven't found a better way to do it so that's why it's commented out.
Without the hook only new sessions will have the new theme.

- **What the hook does:** <!-- e.g. rewrites `theme = "..."` in the app's config so it points at the rendered file -->
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [ ] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
