### PR TITLE
feat: add rio template

### DIFF
--- a/rio/apply.sh
+++ b/rio/apply.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+set -eu
+
+conf_file="${XDG_CONFIG_HOME:-$HOME/.config}/rio/config.toml"
+
+if [ ! -f "$conf_file" ]; then
+    echo 'theme = "noctalia"' > "$conf_file"
+    exit 0
+fi
+
+if grep -q '^[[:space:]]*theme[[:space:]]*=[[:space:]]*"noctalia"' "$conf_file"; then
+    exit 0
+elif grep -q '^[[:space:]]*theme[[:space:]]*=.*'; then
+    sed -i 's/^[[:space:]]*theme[[:space:]]*=.*/theme = "noctalia"/' "$conf_file"
+else
+    sed -i '1i theme = "noctalia"' "$conf_file"
+fi

--- a/rio/rio.toml
+++ b/rio/rio.toml
@@ -1,0 +1,53 @@
+[colors]
+background       = '{{ colors.terminal_background.default.hex }}'
+foreground       = '{{ colors.terminal_foreground.default.hex }}'
+cursor           = '{{ colors.terminal_cursor.default.hex }}'
+vi-cursor        = '{{ colors.terminal_normal_green.default.hex }}'
+
+black            = '{{ colors.terminal_normal_black.default.hex }}'
+red              = '{{ colors.terminal_normal_red.default.hex }}'
+green            = '{{ colors.terminal_normal_green.default.hex }}'
+yellow           = '{{ colors.terminal_normal_yellow.default.hex }}'
+blue             = '{{ colors.terminal_normal_blue.default.hex }}'
+magenta          = '{{ colors.terminal_normal_magenta.default.hex }}'
+cyan             = '{{ colors.terminal_normal_cyan.default.hex }}'
+white            = '{{ colors.terminal_normal_white.default.hex }}'
+
+dim-foreground   = '{{ colors.terminal_foreground.default.hex }}'
+dim-black        = '{{ colors.terminal_normal_black.default.hex }}'
+dim-red          = '{{ colors.terminal_normal_red.default.hex }}'
+dim-green        = '{{ colors.terminal_normal_green.default.hex }}'
+dim-yellow       = '{{ colors.terminal_normal_yellow.default.hex }}'
+dim-blue         = '{{ colors.terminal_normal_blue.default.hex }}'
+dim-magenta      = '{{ colors.terminal_normal_magenta.default.hex }}'
+dim-cyan         = '{{ colors.terminal_normal_cyan.default.hex }}'
+dim-white        = '{{ colors.terminal_normal_white.default.hex }}'
+
+light-foreground = '{{ colors.terminal_foreground.default.hex }}'
+light-black      = '{{ colors.terminal_bright_black.default.hex }}'
+light-red        = '{{ colors.terminal_bright_red.default.hex }}'
+light-green      = '{{ colors.terminal_bright_green.default.hex }}'
+light-yellow     = '{{ colors.terminal_bright_yellow.default.hex }}'
+light-blue       = '{{ colors.terminal_bright_blue.default.hex }}'
+light-magenta    = '{{ colors.terminal_bright_magenta.default.hex }}'
+light-cyan       = '{{ colors.terminal_bright_cyan.default.hex }}'
+light-white      = '{{ colors.terminal_bright_white.default.hex }}'
+
+tabs             = '{{ colors.terminal_normal_black.default.hex }}'
+tabs-active      = '{{ colors.terminal_normal_green.default.hex }}'
+bar              = '{{ colors.terminal_foreground.default.hex }}'
+split            = '{{ colors.terminal_normal_black.default.hex }}'
+
+# Search
+search-match-background          = '{{ colors.terminal_normal_blue.default.hex }}'
+search-match-foreground          = '{{ colors.terminal_normal_black.default.hex }}'
+search-focused-match-background  = '{{ colors.terminal_normal_green.default.hex }}'
+search-focused-match-foreground  = '{{ colors.terminal_normal_black.default.hex }}'
+
+# Hints
+hint-foreground  = '{{ colors.terminal_normal_black.default.hex }}'
+hint-background  = '{{ colors.terminal_normal_yellow.default.hex }}'
+
+# Selection
+selection-foreground = '{{ colors.terminal_selection_fg.default.hex }}'
+selection-background = '{{ colors.terminal_selection_bg.default.hex }}'

--- a/rio/template.toml
+++ b/rio/template.toml
@@ -1,0 +1,8 @@
+[catalog.rio]
+name = "rio"
+category = "terminal"
+
+[templates.rio]
+input_path = "rio.toml"
+output_path = "$XDG_CONFIG_HOME/rio/themes/noctalia.toml"
+post_hook   = "bash '{{ config_dir }}/apply.sh'"


### PR DESCRIPTION
## Template

- **App:** [Rio Terminal](https://rioterm.com/)
- **Template id (directory):** `rio`
- [x] New template
- [ ] Update to an existing template

## Testing

- **App version tested:** `rioterm 0.4.12`
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

Screenshots shows `Wallpaper` theme
<img width="1920" height="1080" alt="screenshot_20260804_085107-region" src="https://github.com/user-attachments/assets/a1bfac62-6ad3-442b-b847-8b8e754bcf6f" />
<img width="1920" height="1080" alt="screenshot_20260804_085129-region" src="https://github.com/user-attachments/assets/db9e71b7-0146-4dd3-ab1f-816bdb1fe01a" />

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
