### PR TITLE
fix(yazi): replace remaining hardcoded Catppuccin colors in tmTheme

### DIFF
--- a/yazi/yazi.tmTheme
+++ b/yazi/yazi.tmTheme
@@ -30,13 +30,13 @@
           <key>accent</key>
           <string>{{colors.primary.default.hex}}</string>
           <key>selection</key>
-          <string>#9399b240</string>
+          <string>{{colors.surface_container_highest.default.hex}}40</string>
           <key>activeGuide</key>
           <string>{{colors.terminal_normal_black.default.hex}}</string>
           <key>findHighlight</key>
-          <string>#3e5767</string>
+          <string>{{colors.secondary_container.default.hex}}</string>
           <key>gutterForeground</key>
-          <string>#7f849c</string>
+          <string>{{colors.outline.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -58,7 +58,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#9399b2</string>
+          <string>{{colors.on_surface_variant.default.hex}}</string>
           <key>fontStyle</key>
           <string/>
         </dict>
@@ -71,7 +71,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#9399b2</string>
+          <string>{{colors.on_surface_variant.default.hex}}</string>
           <key>fontStyle</key>
           <string>italic</string>
         </dict>
@@ -225,7 +225,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
           <key>fontStyle</key>
           <string>italic</string>
         </dict>
@@ -269,7 +269,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -467,7 +467,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -478,7 +478,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -691,7 +691,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -735,7 +735,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#f2cdcd</string>
+          <string>{{colors.on_tertiary_container.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -757,7 +757,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#f2cdcd</string>
+          <string>{{colors.on_tertiary_container.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -871,7 +871,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -893,7 +893,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
           <key>fontStyle</key>
           <string/>
         </dict>
@@ -1027,7 +1027,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1049,7 +1049,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1060,7 +1060,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#f2cdcd</string>
+          <string>{{colors.on_tertiary_container.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1140,7 +1140,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#74c7ec</string>
+          <string>{{colors.terminal_normal_blue.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1149,7 +1149,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#b4befe</string>
+          <string>{{colors.primary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1180,7 +1180,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#a6adc8</string>
+          <string>{{colors.outline_variant.default.hex}}</string>
           <key>fontStyle</key>
           <string>strikethrough</string>
         </dict>
@@ -1204,7 +1204,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#b4befe</string>
+          <string>{{colors.primary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1226,7 +1226,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1237,7 +1237,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#9399b2</string>
+          <string>{{colors.on_surface_variant.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1316,7 +1316,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#b4befe</string>
+          <string>{{colors.primary_fixed_dim.default.hex}}</string>
           <key>fontStyle</key>
           <string/>
         </dict>
@@ -1353,7 +1353,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1375,7 +1375,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1408,7 +1408,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
           <key>fontStyle</key>
           <string>italic</string>
         </dict>
@@ -1456,7 +1456,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1535,7 +1535,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
           <key>fontStyle</key>
           <string>italic</string>
         </dict>
@@ -1872,7 +1872,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#89dceb</string>
+          <string>{{colors.terminal_normal_cyan.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -1894,7 +1894,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#eba0ac</string>
+          <string>{{colors.tertiary_fixed_dim.default.hex}}</string>
         </dict>
       </dict>
       <dict>
@@ -2039,7 +2039,7 @@
         <key>settings</key>
         <dict>
           <key>foreground</key>
-          <string>#9399b2</string>
+          <string>{{colors.on_surface_variant.default.hex}}</string>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
## Summary

`yazi.tmTheme` (the syntax-highlighting flavor file, rendered separately from `yazi.toml` which
#61 already covers for the mime-type filetype rules) is byte-identical to `bat.tmTheme` and has
the exact same gap: 10 distinct Catppuccin Mocha hex values (32 occurrences) hardcoded across the
editor chrome and most syntax-highlighting scopes, never actually following the theme.

Same mapping as the companion `bat` fix, for the same reasoning:

| Catppuccin hex | Used for | Token |
| --- | --- | --- |
| `#9399b240` | selection | `surface_container_highest` + alpha |
| `#3e5767` | find-highlight | `secondary_container` |
| `#7f849c` | gutter foreground | `outline` |
| `#9399b2` | comments, punctuation, code fences | `on_surface_variant` |
| `#eba0ac` | parameters, misc soft accents | `tertiary_fixed_dim` |
| `#89dceb` | function/type support | `terminal_normal_cyan` |
| `#f2cdcd` | GraphQL/LaTeX soft accents | `on_tertiary_container` |
| `#b4befe` | links, h6, nix interpolation | `primary_fixed_dim` |
| `#a6adc8` | strikethrough | `outline_variant` |
| `#74c7ec` | h5 heading | `terminal_normal_blue` |

## Testing

Same method as the `bat` fix: copied into the local materialized template cache, forced a real
re-render via the `settings.toml` `community_ids` off/on toggle, confirmed zero leftover
`{{colors` placeholders and real resolved hex for every token in the actual rendered
`tmtheme.xml` output.

Tested against yazi 26.5.6.

## Checklist

- [x] One app per PR
- [x] Version tested: yazi 26.5.6
- [x] No rendered output or personal app config committed
