### PR TITLE
Fix Zed/Gram Transparency

### DIFF
--- a/zed/zed.json
+++ b/zed/zed.json
@@ -596,7 +596,7 @@
           "{{colors.secondary.dark.hex}}",
           "{{colors.tertiary.dark.hex}}"
         ],
-        "background.appearance": "opaque",
+        "background.appearance": "transparent",
         "border": "{{colors.outline_variant.dark.hex}}",
         "border.variant": "{{colors.outline.dark.hex}}",
         "border.focused": "{{colors.primary.dark.hex}}",
@@ -888,7 +888,7 @@
           "{{colors.secondary.light.hex}}",
           "{{colors.tertiary.light.hex}}"
         ],
-        "background.appearance": "opaque",
+        "background.appearance": "transparent",
         "border": "{{colors.outline_variant.light.hex}}",
         "border.variant": "{{colors.outline.light.hex}}",
         "border.focused": "{{colors.primary.light.hex}}",


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** Zed (& Gram)
- **Template id (directory):** `zed`
- [ ] New template
- [X] Update to an existing template

## What it themes

Fixes the transparent variations not working on Gram & Zed due to `background.appearance` being set to `opaque` instead of `transparent`.

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** <!-- e.g. fuzzel 1.11.0 -->
- [X] Applied a dark theme and confirmed the app picked it up
- [X] Applied a light theme and confirmed the app picked it up
- [X] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- The app running with the theme applied. Required. -->
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/0a513343-2467-4278-b421-2788195a15d8" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/689fc2f9-b92b-4789-a2b6-b5f837d72997" />

## Checklist

- [X] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [X] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [X] Every `input_path` names a file that exists in this directory.
- [X] No generated output or app-specific personal config is committed.
