### PR TITLE
telegram: theme chat scrollbars and selected service bubble

### DIFF
--- a/telegram/telegram.tdesktop-theme
+++ b/telegram/telegram.tdesktop-theme
@@ -21,11 +21,19 @@ windowShadowFgFallback: {{colors.shadow.default.hex}}; // Fallback for shadow
 historyOutIconFg: {{colors.primary.default.hex}};
 historyIconFgInverted: {{colors.on_surface.default.hex}};
 
-msgServiceBg: {{colors.primary_container.default.hex}};
+msgServiceBg: {{colors.surface_variant.default.hex}};
+msgServiceBgSelected: {{colors.secondary_container.default.hex}};
 msgServiceFg: {{colors.on_surface.default.hex}};
-msgOutBg: {{colors.primary_container.default.hex}};
-msgOutBgSelected : {{colors.tertiary_container.default.hex}};
+historyUnreadBarBg: {{colors.surface_variant.default.hex}}; // Unread messages banner background
+historyUnreadBarFg: {{colors.on_surface.default.hex}}; // Unread messages banner text
+historyUnreadBarBorder: {{colors.shadow.default.hex}}00; // Unread messages banner border
+botKbBg: {{colors.surface_variant.default.hex}}; // Inline bot keyboard button background
+botKbDownBg: {{colors.secondary_container.default.hex}}; // Inline bot keyboard button pressed
+msgBotKbIconFg: {{colors.on_surface_variant.default.hex}}; // Inline bot keyboard button icon
+msgOutBg: {{colors.secondary_container.default.hex}};
+msgOutBgSelected: {{colors.surface_container_high.default.hex}};
 msgOutServiceFg: {{colors.on_surface.default.hex}};
+historyTextOutFg: {{colors.on_surface.default.hex}}; // Outgoing bubble text
 msgOutDateFg: {{colors.on_surface.default.hex}};
 historySentIconFg: {{colors.on_surface.default.hex}};
 msgOutDateFgSelected: {{colors.on_surface.default.hex}};
@@ -50,7 +58,22 @@ activeButtonFgOver: {{colors.on_primary_container.default.hex}}; // Active butto
 activeButtonSecondaryFg: {{colors.on_primary.default.hex}}; // Active button secondary text
 activeButtonSecondaryFgOver: {{colors.on_primary_container.default.hex}}; // Active button secondary hover text
 activeLineFg: {{colors.on_surface.default.hex}};
-dialogsBgActive: {{colors.primary.default.hex}};
+dialogsBgActive: {{colors.secondary_container.default.hex}};
+dialogsNameFg: {{colors.on_surface.default.hex}}; // Chat list name text
+dialogsNameFgActive: {{colors.on_surface.default.hex}}; // Selected chat name text (same as bubble text)
+dialogsTextFgActive: {{colors.on_surface.default.hex}}; // Selected chat preview text (same as bubble text)
+dialogsDateFgActive: {{colors.on_surface.default.hex}}; // Selected chat date text (same as bubble text)
+sideBarBg: {{colors.surface_container_lowest.default.hex}}; // Filters side bar background
+sideBarBgActive: {{colors.surface_container.default.hex}}; // Filters side bar active background
+sideBarBgRipple: {{colors.surface_container_low.default.hex}}; // Filters side bar ripple effect
+sideBarTextFg: {{colors.outline.default.hex}}; // Filters side bar text
+sideBarTextFgActive: {{colors.primary.default.hex}}; // Filters side bar active item text
+sideBarIconFg: {{colors.outline.default.hex}}; // Filters side bar icon
+sideBarIconFgActive: {{colors.primary.default.hex}}; // Filters side bar active item icon
+sideBarBadgeBg: {{colors.primary.default.hex}}; // Filters side bar badge background
+sideBarBadgeBgMuted: {{colors.outline.default.hex}}; // Filters side bar muted badge background
+sideBarBadgeFg: {{colors.on_primary.default.hex}}; // Filters side bar badge text
+
 
 lightButtonBg: {{colors.surface.default.hex}}; // Light button background
 lightButtonBgOver: {{colors.surface_variant.default.hex}}; // Light button hover background
@@ -81,6 +104,10 @@ scrollBarBg: {{colors.primary.default.hex}}40; // Scroll bar background (40% opa
 scrollBarBgOver: {{colors.primary.default.hex}}60; // Scroll bar hover background (60% opacity)
 scrollBg: {{colors.surface_variant.default.hex}}40; // Scroll bar track (40% opacity)
 scrollBgOver: {{colors.surface_variant.default.hex}}60; // Scroll bar track on hover (60% opacity)
+historyScrollBarBg: {{colors.on_surface.default.hex}}7a; // Chat scroll bar (48% opacity)
+historyScrollBarBgOver: {{colors.on_surface.default.hex}}bc; // Chat scroll bar on hover (74% opacity)
+historyScrollBg: {{colors.on_surface.default.hex}}4c; // Chat scroll bar track (30% opacity)
+historyScrollBgOver: {{colors.on_surface.default.hex}}6b; // Chat scroll bar track on hover (42% opacity)
 
 smallCloseIconFg: {{colors.outline.default.hex}};
 smallCloseIconFgOver: {{colors.on_surface_variant.default.hex}};


### PR DESCRIPTION
## What

The telegram template left 5 palette keys untemplated, so those colors stayed pinned to the previously-applied theme's values instead of following the active palette:

- `historyScrollBarBg` / `historyScrollBarBgOver` / `historyScrollBg` / `historyScrollBgOver` — chat view scrollbar (bar + track, hover states)
- `msgServiceBgSelected` — selected service message background

## How

Map the 4 scrollbar keys to `on_surface` with the alpha ladder TDesktop itself uses for the in-chat scrollbar (48%/74% bar, 30%/42% track) and `msgServiceBgSelected` to `inverse_primary`.

## Testing

Rendered the template with the Noctalia engine — all 5 new keys resolve, 0 leftover placeholders. Found via diffing the rendered theme against a theme exported from Telegram Desktop: these were the only keys present in the export but absent from the template, keeping stale colors from the previous theme.