### PR TITLE
feat: add eza template

### DIFF
--- a/eza/eza.yml
+++ b/eza/eza.yml
@@ -1,0 +1,182 @@
+colourful: true
+
+# --- File Kinds ---
+filekinds:
+  normal:
+    foreground: "{{ colors.on_surface.default.hex }}"
+  directory:
+    foreground: "{{ colors.primary.default.hex }}"
+    is_bold: true
+  symlink:
+    foreground: "{{ colors.secondary.default.hex }}"
+  pipe:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  block_device:
+    foreground: "{{ colors.tertiary_container.default.hex }}"
+  char_device:
+    foreground: "{{ colors.tertiary_container.default.hex }}"
+  socket:
+    foreground: "{{ colors.outline.default.hex }}"
+  special:
+    foreground: "{{ colors.error.default.hex }}"
+  executable:
+    foreground: "{{ colors.primary_container.default.hex }}"
+    is_bold: true
+  mount_point:
+    foreground: "{{ colors.secondary_container.default.hex }}"
+    is_underline: true
+
+# --- File Types & Categories ---
+file_type:
+  image:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  video:
+    foreground: "{{ colors.tertiary.default.hex }}"
+    is_bold: true
+  music:
+    foreground: "{{ colors.secondary.default.hex }}"
+  crypto:
+    foreground: "{{ colors.primary.default.hex }}"
+  document:
+    foreground: "{{ colors.on_surface_variant.default.hex }}"
+  compressed:
+    foreground: "{{ colors.error.default.hex }}"
+  temp:
+    foreground: "{{ colors.outline.default.hex }}"
+    is_dimmed: true
+  compiled:
+    foreground: "{{ colors.outline_variant.default.hex }}"
+    is_dimmed: true
+  build:
+    foreground: "{{ colors.primary_fixed.default.hex }}"
+    is_underline: true
+  source:
+    foreground: "{{ colors.primary.default.hex }}"
+
+# --- File Permissions ---
+perms:
+  user_read:
+    foreground: "{{ colors.on_surface.default.hex }}"
+  user_write:
+    foreground: "{{ colors.error.default.hex }}"
+  user_execute_file:
+    foreground: "{{ colors.primary.default.hex }}"
+    is_bold: true
+  user_execute_other:
+    foreground: "{{ colors.primary.default.hex }}"
+  group_read:
+    foreground: "{{ colors.on_surface_variant.default.hex }}"
+  group_write:
+    foreground: "{{ colors.error_container.default.hex }}"
+  group_execute:
+    foreground: "{{ colors.secondary.default.hex }}"
+  other_read:
+    foreground: "{{ colors.outline.default.hex }}"
+  other_write:
+    foreground: "{{ colors.error_container.default.hex }}"
+  other_execute:
+    foreground: "{{ colors.outline.default.hex }}"
+  special_user_file:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  special_other:
+    foreground: "{{ colors.tertiary_container.default.hex }}"
+  attribute:
+    foreground: "{{ colors.outline_variant.default.hex }}"
+
+# --- File Size ---
+size:
+  number_byte:
+    foreground: "{{ colors.on_surface_variant.default.hex }}"
+  number_kilo:
+    foreground: "{{ colors.on_surface.default.hex }}"
+  number_mega:
+    foreground: "{{ colors.primary.default.hex }}"
+  number_giga:
+    foreground: "{{ colors.secondary.default.hex }}"
+  number_huge:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  unit_byte:
+    foreground: "{{ colors.outline.default.hex }}"
+  unit_kilo:
+    foreground: "{{ colors.on_surface_variant.default.hex }}"
+  unit_mega:
+    foreground: "{{ colors.primary.default.hex }}"
+  unit_giga:
+    foreground: "{{ colors.secondary.default.hex }}"
+  unit_huge:
+    foreground: "{{ colors.tertiary.default.hex }}"
+
+# --- Users & Groups ---
+users:
+  user_you:
+    foreground: "{{ colors.primary.default.hex }}"
+    is_bold: true
+  user_root:
+    foreground: "{{ colors.error.default.hex }}"
+    is_bold: true
+  user_other:
+    foreground: "{{ colors.outline.default.hex }}"
+  group_yours:
+    foreground: "{{ colors.secondary.default.hex }}"
+  group_root:
+    foreground: "{{ colors.error_container.default.hex }}"
+  group_other:
+    foreground: "{{ colors.outline.default.hex }}"
+
+# --- Git Status ---
+git:
+  new:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  modified:
+    foreground: "{{ colors.secondary.default.hex }}"
+  deleted:
+    foreground: "{{ colors.error.default.hex }}"
+  renamed:
+    foreground: "{{ colors.primary.default.hex }}"
+  ignored:
+    foreground: "{{ colors.outline.default.hex }}"
+    is_dimmed: true
+  conflicted:
+    foreground: "{{ colors.error.default.hex }}"
+    is_bold: true
+
+# --- Git Repository ---
+git_repo:
+  branch_main:
+    foreground: "{{ colors.primary.default.hex }}"
+    is_bold: true
+  branch_other:
+    foreground: "{{ colors.secondary.default.hex }}"
+  git_clean:
+    foreground: "{{ colors.tertiary.default.hex }}"
+  git_dirty:
+    foreground: "{{ colors.error.default.hex }}"
+
+# --- UI & Meta Elements ---
+punctuation:
+  foreground: "{{ colors.outline.default.hex }}"
+
+date:
+  foreground: "{{ colors.on_surface_variant.default.hex }}"
+
+header:
+  foreground: "{{ colors.on_surface.default.hex }}"
+  is_bold: true
+  is_underline: true
+
+inode:
+  foreground: "{{ colors.outline_variant.default.hex }}"
+
+blocks:
+  foreground: "{{ colors.outline_variant.default.hex }}"
+
+octal:
+  foreground: "{{ colors.secondary.default.hex }}"
+
+broken_symlink:
+  foreground: "{{ colors.error.default.hex }}"
+  is_bold: true
+
+broken_path_overlay:
+  foreground: "{{ colors.on_error.default.hex }}"
+  background: "{{ colors.error.default.hex }}"

--- a/eza/template.toml
+++ b/eza/template.toml
@@ -1,0 +1,7 @@
+[catalog.eza]
+name = "eza"
+category = "terminal"
+
+[templates.eza]
+input_path = "eza.yml"
+output_path = "$XDG_CONFIG_HOME/eza/theme.yml"


### PR DESCRIPTION
## Template

- **App:** [eza](https://eza.rocks/)
- **Template id (directory):** `eza`
- [x] New template
- [ ] Update to an existing template

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** <!-- e.g. fuzzel 1.11.0 -->
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<img width="691" height="879" alt="screenshot_20260807_125301-region" src="https://github.com/user-attachments/assets/bae1c12a-84cf-427b-a653-326ca05cab9b" />
<img width="724" height="965" alt="screenshot_20260807_125322-region" src="https://github.com/user-attachments/assets/5ae9ec75-53d4-47a9-8204-3d5930f2347e" />


## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
