### PR TITLE
made some elements in neovim readable

### DIFF
--- a/neovim/matugen-template.lua
+++ b/neovim/matugen-template.lua
@@ -17,7 +17,7 @@ function M.setup()
     base0C = '{{colors.tertiary_fixed_dim.default.hex}}',
     base0D = '{{colors.primary_fixed_dim.default.hex}}',
     base0E = '{{colors.secondary_fixed_dim.default.hex}}',
-    base0F = '{{colors.error_container.default.hex}}',
+    base0F = '{{colors.secondary_fixed.default.hex}}',
   })
 
   local hi = function(group, opts)


### PR DESCRIPTION
one line change changing base0F from error_container to secondary_fixed, since the former was almost always very difficult to read

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** neovim
- **Template id (directory):** neovim
- [ ] New template
- [x] Update to an existing template

## What it themes
same as before

## Testing

using it right now, this is before
<img width="141" height="115" alt="image" src="https://github.com/user-attachments/assets/862e9aaf-9b8b-47e5-82bc-a4a9bd76d47b" />
this is after
<img width="138" height="106" alt="image" src="https://github.com/user-attachments/assets/0bb4accb-dbec-49d5-b3a2-6f43440be495" />
tried with a bunch of other wallpapers, light theme, and some built-in schemes. looks fine imo.



- **App version tested:**
NVIM v0.12.4
Build type: RelWithDebInfo
LuaJIT 2.1.1785763465
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<img width="1012" height="707" alt="image" src="https://github.com/user-attachments/assets/8528e5d3-92a1-47ec-890e-4cace4e676aa" />

## Hooks
hook is unchanged

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
