### PR TITLE
Fix neovim SIGUSR1 handler stacking on theme reload

### DIFF
--- a/neovim/matugen-template.lua
+++ b/neovim/matugen-template.lua
@@ -38,14 +38,22 @@ function M.setup()
   hi('TelescopeMatching',       { fg = '{{colors.primary.default.hex}}',             bold = true })
 end
 
- -- Register a signal handler for SIGUSR1 (matugen updates)
- local signal = vim.uv.new_signal()
- signal:start(
-   'sigusr1',
-   vim.schedule_wrap(function()
-     package.loaded['matugen'] = nil
-     require('matugen').setup()
-   end)
- )
+-- Register a signal handler for SIGUSR1 (matugen updates).
+-- The handler re-requires this module, which re-runs the code below, so the
+-- previous handle is stopped first; otherwise handlers double on every signal.
+if _G.__matugen_signal then
+  _G.__matugen_signal:stop()
+  _G.__matugen_signal:close()
+end
 
- return M
+local signal = vim.uv.new_signal()
+_G.__matugen_signal = signal
+signal:start(
+  'sigusr1',
+  vim.schedule_wrap(function()
+    package.loaded['matugen'] = nil
+    require('matugen').setup()
+  end)
+)
+
+return M


### PR DESCRIPTION
## Summary
- Stop and close the previous `vim.uv` SIGUSR1 handle before registering a new one in `neovim/matugen-template.lua`.
- Without this, each theme reload (`package.loaded['matugen'] = nil` + re-require) stacked another handler, so reloads multiplied over time.

## Test plan
- [x] Enable the `neovim` community template and open nvim with the rendered `matugen.lua`
- [x] Change the Noctalia theme several times (or send repeated `pkill -SIGUSR1 nvim`)
- [x] Confirm colors still update and handlers do not accumulate (no growing reload fan-out)