### PR TITLE
Add qutebrowser template

### DIFF
--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -15,6 +15,7 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
    [theme.templates.user.qutebrowser]
    input_path  = "~/.config/qutebrowser/noctalia/template.py"
    output_path = "~/.config/qutebrowser/noctalia/colors.py"
+   post_hook   = "qutebrowser :config-source"
    ```
 
 3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:
@@ -24,7 +25,7 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
 
 4. Trigger a theme regeneration (change wallpaper, or re-select the current one) so matugen renders `template.py` into `colors.py` for the first time.
 
-5. Reload qutebrowser's config with `:config-source`, or restart it.
+That's it — no manual reload needed after the first run. `post_hook` sends `:config-source` to qutebrowser's IPC socket every time the theme regenerates, so an already-running instance picks up the new colors automatically. If qutebrowser isn't running when the hook fires, this simply launches a fresh instance instead (harmless, just not instant theming until you actually open the browser).
 
 Your color scheme should now update automatically every time Noctalia's theme regenerates.
 

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -4,24 +4,30 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
 
 ## Setup
 
-1. Copy `template.py` into your qutebrowser config folder:
-   ```bash
+**If you're using Noctalia's community-templates catalog:** just enable the `qutebrowser` template from the catalog — the repo (including `template.py` and `reload.sh`) is cloned to `~/.cache/noctalia/community-templates/` automatically, so `templates.toml` and the hook path already resolve correctly. Skip to step 3.
+
+**Manual / standalone setup:**
+
+1. Copy `template.py` and `reload.sh` into your qutebrowser config folder:
+```bash
    mkdir -p ~/.config/qutebrowser/noctalia
    cp template.py ~/.config/qutebrowser/noctalia/template.py
-   ```
+   cp reload.sh ~/.config/qutebrowser/noctalia/reload.sh
+```
 
 2. Register it with matugen by adding this to your Noctalia user templates config (`~/.config/noctalia/templates.toml`):
-   ```toml
+```toml
    [theme.templates.user.qutebrowser]
    input_path  = "~/.config/qutebrowser/noctalia/template.py"
    output_path = "~/.config/qutebrowser/noctalia/colors.py"
-   post_hook   = "sh ~/.cache/noctalia/community-templates/qutebrowser/reload.sh"
-   ```
+   post_hook   = "sh ~/.config/qutebrowser/noctalia/reload.sh"
+```
+   (Point `post_hook` at wherever you actually placed `reload.sh` — the catalog default of `~/.cache/noctalia/community-templates/qutebrowser/reload.sh` only exists if you installed via the catalog.)
 
 3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:
-   ```python
+```python
    config.source('noctalia/colors.py')
-   ```
+```
 
 4. Trigger a theme regeneration (change wallpaper, or re-select the current one) so matugen renders `template.py` into `colors.py` for the first time.
 

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -15,7 +15,7 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
    [theme.templates.user.qutebrowser]
    input_path  = "~/.config/qutebrowser/noctalia/template.py"
    output_path = "~/.config/qutebrowser/noctalia/colors.py"
-   post_hook   = "qutebrowser :config-source"
+   post_hook   = "pgrep -x qutebrowser >/dev/null && qutebrowser :config-source"
    ```
 
 3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:
@@ -25,9 +25,9 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
 
 4. Trigger a theme regeneration (change wallpaper, or re-select the current one) so matugen renders `template.py` into `colors.py` for the first time.
 
-That's it — no manual reload needed after the first run. `post_hook` sends `:config-source` to qutebrowser's IPC socket every time the theme regenerates, so an already-running instance picks up the new colors automatically. If qutebrowser isn't running when the hook fires, this simply launches a fresh instance instead (harmless, just not instant theming until you actually open the browser).
+That's it — no manual reload needed after the first run. The `post_hook` first checks whether qutebrowser is already running (`pgrep -x qutebrowser`); only if it finds a running instance does it send `:config-source` over qutebrowser's IPC socket to reload the new colors. If qutebrowser isn't open, the hook does nothing and won't launch a new window — so theme changes never interrupt you with an unwanted qutebrowser window popping up.
 
-Your color scheme should now update automatically every time Noctalia's theme regenerates.
+Your color scheme should now update automatically every time Noctalia's theme regenerates, but only while qutebrowser is actually open.
 
 ## Why a helper function is in the template
 
@@ -49,3 +49,5 @@ This has to live in `template.py` itself, not in the generated `colors.py`. Sinc
 
 - Requires qutebrowser's `config.py` to exist and call `config.load_autoconfig(True)` (the default) so both the generated colors and your own settings load together.
 - Tested with qutebrowser v3.7.0 / QtWebEngine 6.11.
+
+> **Tip:** `:config-source` re-runs your entire `config.py` from top to bottom, not just the colors. If `config.load_autoconfig(True)` is called near the *top* of your `config.py`, any settings you toggle at runtime (`:config-cycle`, `:set`, etc. — saved to `autoconfig.yml`) will get overwritten by whatever hardcoded values come after it in the file, resetting things like dark mode or tab position back to your defaults every time the theme regenerates. Move `config.load_autoconfig(True)` to the **bottom** of `config.py`, after all your other settings, so your current session state loads last and wins.

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -10,12 +10,12 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
    cp template.py ~/.config/qutebrowser/noctalia/template.py
    ```
 
-2. Register it with matugen by adding this to your Noctalia user templates config (`~/.config/noctalia/user-templates.toml`):
+2. Register it with matugen by adding this to your Noctalia user templates config (`~/.config/noctalia/templates.toml`):
    ```toml
    [theme.templates.user.qutebrowser]
    input_path  = "~/.config/qutebrowser/noctalia/template.py"
    output_path = "~/.config/qutebrowser/noctalia/colors.py"
-   post_hook   = "pgrep -x qutebrowser >/dev/null && qutebrowser :config-source"
+   post_hook   = "sh ~/.cache/noctalia/community-templates/qutebrowser/reload.sh"
    ```
 
 3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -1,0 +1,50 @@
+# qutebrowser
+
+Matugen template that themes qutebrowser (completion menu, hints, tabs, statusbar, prompts, messages, downloads bar) to match your current Noctalia color scheme.
+
+## Setup
+
+1. Copy `template.py` into your qutebrowser config folder:
+   ```bash
+   mkdir -p ~/.config/qutebrowser/noctalia
+   cp template.py ~/.config/qutebrowser/noctalia/template.py
+   ```
+
+2. Register it with matugen by adding this to your Noctalia user templates config (`~/.config/noctalia/user-templates.toml`):
+   ```toml
+   [theme.templates.user.qutebrowser]
+   input_path  = "~/.config/qutebrowser/noctalia/template.py"
+   output_path = "~/.config/qutebrowser/noctalia/colors.py"
+   ```
+
+3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:
+   ```python
+   config.source('noctalia/colors.py')
+   ```
+
+4. Trigger a theme regeneration (change wallpaper, or re-select the current one) so matugen renders `template.py` into `colors.py` for the first time.
+
+5. Reload qutebrowser's config with `:config-source`, or restart it.
+
+Your color scheme should now update automatically every time Noctalia's theme regenerates.
+
+## Why a helper function is in the template
+
+A few qutebrowser settings (hint label backgrounds, tab bar background, etc.) need an `rgba()` string for transparency, not a bare hex value. matugen only outputs hex, so a small conversion helper is defined directly inside the template:
+
+```python
+def hex_to_rgba(hex_color, alpha):
+    """Convert a #rrggbb hex string to a qutebrowser-compatible rgba() string."""
+    hex_color = hex_color.lstrip('#')
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return 'rgba({}, {}, {}, {})'.format(r, g, b, alpha)
+```
+
+This has to live in `template.py` itself, not in the generated `colors.py`. Since `colors.py` is fully overwritten on every theme regeneration, adding the function only to the generated file means it disappears the next time the theme changes — and qutebrowser will throw `NameError: name 'hex_to_rgba' is not defined` on the next launch, since a later line in the file calls it. Keeping it in the template ensures it survives every regeneration.
+
+## Notes
+
+- Requires qutebrowser's `config.py` to exist and call `config.load_autoconfig(True)` (the default) so both the generated colors and your own settings load together.
+- Tested with qutebrowser v3.7.0 / QtWebEngine 6.11.

--- a/qutebrowser/reload.sh
+++ b/qutebrowser/reload.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pgrep -x qutebrowser >/dev/null && qutebrowser :config-source

--- a/qutebrowser/template.py
+++ b/qutebrowser/template.py
@@ -1,0 +1,364 @@
+# Noctalia qutebrowser theme - Material Design 3 Colors
+# Auto-generated from matugen color schemes
+# Theme adapts automatically based on your wallpaper and noctalia settings
+#
+# Color Mapping:
+# - Surface colors for backgrounds (surface, surface_container, surface_variant)
+# - Primary colors for accents and highlights
+# - Secondary colors for complementary elements
+# - Tertiary colors for additional accents
+# - Error colors for warnings and errors
+# - Outline colors for borders and separators
+
+# Base Surface Colors
+surface = "{{colors.surface.default.hex}}"
+surface_dim = "{{colors.surface_dim.default.hex}}"
+surface_bright = "{{colors.surface_bright.default.hex}}"
+surface_container = "{{colors.surface_container.default.hex}}"
+surface_container_low = "{{colors.surface_container_low.default.hex}}"
+surface_container_lowest = "{{colors.surface_container_lowest.default.hex}}"
+surface_container_high = "{{colors.surface_container_high.default.hex}}"
+surface_container_highest = "{{colors.surface_container_highest.default.hex}}"
+surface_variant = "{{colors.surface_variant.default.hex}}"
+
+# Foreground Colors
+on_surface = "{{colors.on_surface.default.hex}}"
+on_surface_variant = "{{colors.on_surface_variant.default.hex}}"
+
+# Primary Colors
+primary = "{{colors.primary.default.hex}}"
+on_primary = "{{colors.on_primary.default.hex}}"
+primary_container = "{{colors.primary_container.default.hex}}"
+on_primary_container = "{{colors.on_primary_container.default.hex}}"
+
+# Secondary Colors
+secondary = "{{colors.secondary.default.hex}}"
+on_secondary = "{{colors.on_secondary.default.hex}}"
+secondary_container = "{{colors.secondary_container.default.hex}}"
+on_secondary_container = "{{colors.on_secondary_container.default.hex}}"
+
+# Tertiary Colors
+tertiary = "{{colors.tertiary.default.hex}}"
+on_tertiary = "{{colors.on_tertiary.default.hex}}"
+tertiary_container = "{{colors.tertiary_container.default.hex}}"
+on_tertiary_container = "{{colors.on_tertiary_container.default.hex}}"
+
+# Error Colors
+error = "{{colors.error.default.hex}}"
+on_error = "{{colors.on_error.default.hex}}"
+error_container = "{{colors.error_container.default.hex}}"
+on_error_container = "{{colors.on_error_container.default.hex}}"
+
+# Outline Colors
+outline = "{{colors.outline.default.hex}}"
+outline_variant = "{{colors.outline_variant.default.hex}}"
+
+# Special Colors
+inverse_surface = "{{colors.inverse_surface.default.hex}}"
+inverse_on_surface = "{{colors.inverse_on_surface.default.hex}}"
+inverse_primary = "{{colors.inverse_primary.default.hex}}"
+
+# Utility function to convert a #rrggbb hex color to an rgba() string with transparency.
+def hex_to_rgba(hex_color, alpha):
+    """Convert a #rrggbb hex string to a qutebrowser-compatible rgba() string."""
+    hex_color = hex_color.lstrip('#')
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return 'rgba({}, {}, {}, {})'.format(r, g, b, alpha)
+
+
+### Completion
+
+# Text color of the completion widget. May be a single color to use for
+# all columns or a list of three colors, one for each column.
+c.colors.completion.fg = [on_surface, primary, tertiary]
+
+# Background color of the completion widget for odd rows.
+c.colors.completion.odd.bg = surface_container
+
+# Background color of the completion widget for even rows.
+c.colors.completion.even.bg = surface_container_low
+
+# Foreground color of completion widget category headers.
+c.colors.completion.category.fg = primary
+
+# Background color of the completion widget category headers.
+c.colors.completion.category.bg = surface_container_high
+
+# Top border color of the completion widget category headers.
+c.colors.completion.category.border.top = outline_variant
+
+# Bottom border color of the completion widget category headers.
+c.colors.completion.category.border.bottom = outline_variant
+
+# Foreground color of the selected completion item.
+c.colors.completion.item.selected.fg = on_primary_container
+
+# Background color of the selected completion item.
+c.colors.completion.item.selected.bg = primary_container
+
+# Top border color of the selected completion item.
+c.colors.completion.item.selected.border.top = primary_container
+
+# Bottom border color of the selected completion item.
+c.colors.completion.item.selected.border.bottom = primary_container
+
+# Foreground color of the matched text in the selected completion item.
+c.colors.completion.item.selected.match.fg = tertiary
+
+# Foreground color of the matched text in the completion.
+c.colors.completion.match.fg = tertiary
+
+# Color of the scrollbar handle in the completion view.
+c.colors.completion.scrollbar.fg = primary
+
+# Color of the scrollbar in the completion view.
+c.colors.completion.scrollbar.bg = surface_variant
+
+### Context menu
+
+# Background color of disabled items in the context menu.
+c.colors.contextmenu.disabled.bg = surface_variant
+
+# Foreground color of disabled items in the context menu.
+c.colors.contextmenu.disabled.fg = on_surface_variant
+
+# Background color of the context menu. If set to null, the Qt default is used.
+c.colors.contextmenu.menu.bg = surface_container
+
+# Foreground color of the context menu. If set to null, the Qt default is used.
+c.colors.contextmenu.menu.fg = on_surface
+
+# Background color of the context menu's selected item. If set to null, the Qt default is used.
+c.colors.contextmenu.selected.bg = secondary_container
+
+# Foreground color of the context menu's selected item. If set to null, the Qt default is used.
+c.colors.contextmenu.selected.fg = on_secondary_container
+
+### Downloads
+
+# Background color for the download bar.
+c.colors.downloads.bar.bg = surface
+
+# Color gradient start for download text.
+c.colors.downloads.start.fg = on_primary
+
+# Color gradient start for download backgrounds.
+c.colors.downloads.start.bg = primary
+
+# Color gradient end for download text.
+c.colors.downloads.stop.fg = on_secondary
+
+# Color gradient stop for download backgrounds.
+c.colors.downloads.stop.bg = secondary
+
+# Foreground color for downloads with errors.
+c.colors.downloads.error.fg = error
+
+### Hints
+
+# Font color for hints.
+c.colors.hints.fg = primary
+
+# Background color for hints.
+c.colors.hints.bg = hex_to_rgba(on_primary, 0.7)
+
+# Font color for the matched part of hints.
+c.colors.hints.match.fg = on_primary_container
+
+# Border around hint labels.
+c.hints.border = f'1px solid {primary}'
+
+# Corner rounding for hint labels.
+c.hints.radius = 1
+
+### Keyhint widget
+
+# Text color for the keyhint widget.
+c.colors.keyhint.fg = on_surface_variant
+
+# Highlight color for keys to complete the current keychain.
+c.colors.keyhint.suffix.fg = primary
+
+# Background color of the keyhint widget.
+c.colors.keyhint.bg = surface_container
+
+### Messages
+
+# Foreground color of an error message.
+c.colors.messages.error.fg = on_error
+
+# Background color of an error message.
+c.colors.messages.error.bg = error
+
+# Border color of an error message.
+c.colors.messages.error.border = error
+
+# Foreground color of a warning message.
+c.colors.messages.warning.fg = on_error_container
+
+# Background color of a warning message.
+c.colors.messages.warning.bg = error_container
+
+# Border color of a warning message.
+c.colors.messages.warning.border = error_container
+
+# Foreground color of an info message.
+c.colors.messages.info.fg = on_surface
+
+# Background color of an info message.
+c.colors.messages.info.bg = surface_container
+
+# Border color of an info message.
+c.colors.messages.info.border = outline
+
+### Prompts
+
+# Foreground color for prompts.
+c.colors.prompts.fg = on_surface
+
+# Border used around UI elements in prompts.
+c.colors.prompts.border = f'1px solid {outline}'
+
+# Background color for prompts.
+c.colors.prompts.bg = surface_container_high
+
+# Background color for the selected item in filename prompts.
+c.colors.prompts.selected.bg = secondary_container
+
+### Statusbar
+
+# Foreground color of the statusbar.
+c.colors.statusbar.normal.fg = on_surface
+
+# Background color of the statusbar.
+c.colors.statusbar.normal.bg = surface
+
+# Foreground color of the statusbar in insert mode.
+c.colors.statusbar.insert.fg = on_primary
+
+# Background color of the statusbar in insert mode.
+c.colors.statusbar.insert.bg = primary
+
+# Foreground color of the statusbar in passthrough mode.
+c.colors.statusbar.passthrough.fg = on_secondary
+
+# Background color of the statusbar in passthrough mode.
+c.colors.statusbar.passthrough.bg = secondary
+
+# Foreground color of the statusbar in private browsing mode.
+c.colors.statusbar.private.fg = tertiary
+
+# Background color of the statusbar in private browsing mode.
+c.colors.statusbar.private.bg = surface
+
+# Foreground color of the statusbar in command mode.
+c.colors.statusbar.command.fg = on_surface
+
+# Background color of the statusbar in command mode.
+c.colors.statusbar.command.bg = surface_container
+
+# Foreground color of the statusbar in private browsing + command mode.
+c.colors.statusbar.command.private.fg = tertiary
+
+# Background color of the statusbar in private browsing + command mode.
+c.colors.statusbar.command.private.bg = surface_container
+
+# Foreground color of the statusbar in caret mode.
+c.colors.statusbar.caret.fg = on_tertiary
+
+# Background color of the statusbar in caret mode.
+c.colors.statusbar.caret.bg = tertiary
+
+# Foreground color of the statusbar in caret mode with a selection.
+c.colors.statusbar.caret.selection.fg = on_tertiary_container
+
+# Background color of the statusbar in caret mode with a selection.
+c.colors.statusbar.caret.selection.bg = tertiary_container
+
+# Background color of the progress bar.
+c.colors.statusbar.progress.bg = primary
+
+# Default foreground color of the URL in the statusbar.
+c.colors.statusbar.url.fg = on_surface_variant
+
+# Foreground color of the URL in the statusbar on error.
+c.colors.statusbar.url.error.fg = error
+
+# Foreground color of the URL in the statusbar for hovered links.
+c.colors.statusbar.url.hover.fg = primary
+
+# Foreground color of the URL in the statusbar on successful load (http).
+c.colors.statusbar.url.success.http.fg = error
+
+# Foreground color of the URL in the statusbar on successful load (https).
+c.colors.statusbar.url.success.https.fg = secondary
+
+# Foreground color of the URL in the statusbar when there's a warning.
+c.colors.statusbar.url.warn.fg = tertiary
+
+### Tabs
+
+# Background color of the tab bar.
+c.colors.tabs.bar.bg = hex_to_rgba(surface, 1)
+
+# Color gradient start for the tab indicator.
+c.colors.tabs.indicator.start = primary
+
+# Color gradient end for the tab indicator.
+c.colors.tabs.indicator.stop = secondary
+
+# Color for the tab indicator on errors.
+c.colors.tabs.indicator.error = error
+
+# Foreground color of unselected odd tabs.
+c.colors.tabs.odd.fg = on_surface_variant
+
+# Background color of unselected odd tabs.
+c.colors.tabs.odd.bg = hex_to_rgba(surface_container, 1)
+
+# Foreground color of unselected even tabs.
+c.colors.tabs.even.fg = on_surface_variant
+
+# Background color of unselected even tabs.
+c.colors.tabs.even.bg = hex_to_rgba(surface_container_high, 1)
+
+# Foreground color of selected odd tabs.
+c.colors.tabs.selected.odd.fg = on_primary_container
+
+# Background color of selected odd tabs.
+c.colors.tabs.selected.odd.bg = hex_to_rgba(primary_container, 1)
+
+# Foreground color of selected even tabs.
+c.colors.tabs.selected.even.fg = on_primary_container
+
+# Background color of selected even tabs.
+c.colors.tabs.selected.even.bg = hex_to_rgba(primary_container, 1)
+
+# Background color of pinned unselected even tabs.
+c.colors.tabs.pinned.even.bg = hex_to_rgba(secondary_container, 1)
+
+# Foreground color of pinned unselected even tabs.
+c.colors.tabs.pinned.even.fg = on_secondary_container
+
+# Background color of pinned unselected odd tabs.
+c.colors.tabs.pinned.odd.bg = hex_to_rgba(secondary_container, 1)
+
+# Foreground color of pinned unselected odd tabs.
+c.colors.tabs.pinned.odd.fg = on_secondary_container
+
+# Background color of pinned selected even tabs.
+c.colors.tabs.pinned.selected.even.bg = hex_to_rgba(primary_container, 1)
+
+# Foreground color of pinned selected even tabs.
+c.colors.tabs.pinned.selected.even.fg = on_primary_container
+
+# Background color of pinned selected odd tabs.
+c.colors.tabs.pinned.selected.odd.bg = hex_to_rgba(primary_container, 1)
+
+# Foreground color of pinned selected odd tabs.
+c.colors.tabs.pinned.selected.odd.fg = on_primary_container
+
+# Background color for webpages if unset (or empty to use the theme's color).
+c.colors.webpage.bg = surface

--- a/qutebrowser/template.toml
+++ b/qutebrowser/template.toml
@@ -5,4 +5,5 @@ category = "browser"
 [templates.qutebrowser]
 input_path = "template.py"
 output_path = "$XDG_CONFIG_HOME/qutebrowser/noctalia/colors.py"
+post_hook = "qutebrowser :config-source"
 

--- a/qutebrowser/template.toml
+++ b/qutebrowser/template.toml
@@ -1,0 +1,8 @@
+[catalog.qutebrowser]
+name = "qutebrowser"
+category = "browser"
+
+[templates.qutebrowser]
+input_path = "template.py"
+output_path = "$XDG_CONFIG_HOME/qutebrowser/noctalia/colors.py"
+

--- a/qutebrowser/template.toml
+++ b/qutebrowser/template.toml
@@ -5,5 +5,4 @@ category = "browser"
 [templates.qutebrowser]
 input_path = "template.py"
 output_path = "$XDG_CONFIG_HOME/qutebrowser/noctalia/colors.py"
-post_hook = "pgrep -x qutebrowser >/dev/null && qutebrowser :config-source"
-
+post_hook = "sh ~/.cache/noctalia/community-templates/qutebrowser/reload.sh"

--- a/qutebrowser/template.toml
+++ b/qutebrowser/template.toml
@@ -5,5 +5,5 @@ category = "browser"
 [templates.qutebrowser]
 input_path = "template.py"
 output_path = "$XDG_CONFIG_HOME/qutebrowser/noctalia/colors.py"
-post_hook = "qutebrowser :config-source"
+post_hook = "pgrep -x qutebrowser >/dev/null && qutebrowser :config-source"
 


### PR DESCRIPTION
## Template

- **App:** qutebrowser
- **Template id (directory):** `qutebrowser`
- [x] New template
~~- [ ] Update to an existing template~~

## What it themes

Themes qutebrowser's completion menu, hints, tabs, statusbar, prompts, messages, and downloads bar to match the current Noctalia color scheme. 

**Additionally**: Also includes a `hex_to_rgba()` helper baked into the template so settings requiring transparency (hint backgrounds, tab bar) render correctly, since matugen only outputs bare hex.

## Testing

- **App version tested:** qutebrowser 3.7.0
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

**Note on reload behavior:** the `post_hook` only reloads qutebrowser if it's already running (via a `pgrep` check), so a theme regeneration never launches a new qutebrowser window if one wasn't already open. If qutebrowser is running, `:config-source` fires automatically over its IPC socket — no manual action needed.

## Screenshots

> **Theme Tested**: Kemuri Coke (Community)
###### However, it also works with *Built-In*, *Wallpaper*, and *Custom Themes*.

#### Dark & Light Mode

<img width="1378" height="869" alt="dark_mode" src="https://github.com/user-attachments/assets/05b79df3-4df6-4d3b-9fa5-ef8be9e0c588" />

<img width="1378" height="869" alt="light_mode" src="https://github.com/user-attachments/assets/c91aeca9-b301-414c-9949-68f0f577af14" />

#### Dark & Light Mode with Hints:

<img width="1378" height="869" alt="dark_mode_hints" src="https://github.com/user-attachments/assets/d1a27b73-b8e9-4d9d-a520-5eb157d4dc4f" />

<img width="1378" height="869" alt="light_mode_hints" src="https://github.com/user-attachments/assets/554b66c3-f162-4aa4-a669-975a32f1f071" />

## Hooks

- **What the hook does:** `pgrep -x qutebrowser >/dev/null && qutebrowser :config-source` — checks if a qutebrowser process is already running; if so, sends `:config-source` over IPC to reload the newly generated colors. If qutebrowser isn't running, the hook exits immediately and does nothing (no new window is opened).
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.
- [ ] It fails loudly (non-zero exit, message on stderr) when the app's config is missing. — *Not applicable in the traditional sense: if `config.py` or `colors.py` has an error, qutebrowser surfaces it as an in-app red error banner rather than a stderr message, since `:config-source` runs inside the browser's own process, not as a standalone script.*

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
