### PR TITLE
Fix: (qutebrowser) add check for colors.py modification time in reload.sh

### DIFF
--- a/qutebrowser/reload.sh
+++ b/qutebrowser/reload.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
+COLORS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/noctalia/colors.py"
+
+[ "$COLORS_FILE" -nt "$0" ] || exit 0
+touch "$0"
+
 pgrep -x qutebrowser >/dev/null && qutebrowser :config-source


### PR DESCRIPTION
Check if colors.py is newer than the script before executing. This fixes the behavior of script execution whenever the user changes templates of any other gui/cli app through Noctalia. It'll only check if there has been any changes in colors.py and then execute the script. A silly bug fix indeed.

## Template
- **App:** qutebrowser
- **Template id (directory):** `qutebrowser`
- [x] Update to an existing template

## What it themes
No change to what's themed — this only touches `reload.sh`, the `post_hook` script. Previously it reloaded qutebrowser on *any* Noctalia theme-apply event, even when a completely unrelated app's template was the one that changed (e.g. tweaking btop's theme would still trigger a qutebrowser reload). Now it compares `colors.py`'s modification time against the script's own, and only reloads qutebrowser when its own generated colors actually changed.

## Testing
- **App version tested:** qutebrowser 3.7.0
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

Also confirmed: changing a different app's theme (e.g. btop) through Noctalia no longer triggers a qutebrowser reload, since `colors.py`'s mtime doesn't change when qutebrowser's own template wasn't re-rendered with different content-relevant timing.

## Hooks
- **What the hook does:** Checks if `colors.py` is newer than the script itself (`[ "$COLORS_FILE" -nt "$0" ]`). If not, exits immediately without touching qutebrowser. If it is newer, updates the script's own mtime (`touch "$0"`) as the new baseline, then checks if qutebrowser is running (`pgrep -x qutebrowser`) and only then sends `:config-source` to reload.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist
- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.