### PR TITLE
feat: add fzf template

### DIFF
--- a/fzf/fzf.fish
+++ b/fzf/fzf.fish
@@ -1,0 +1,23 @@
+set -l fzf_theme_opts "\
+--color=bg+:{{colors.surface_variant.default.hex}}
+--color=bg:{{colors.surface.default.hex}}
+--color=spinner:{{colors.terminal_cursor.default.hex}}
+--color=hl:{{colors.error.default.hex}}
+--color=fg:{{colors.terminal_foreground.default.hex}}
+--color=header:{{colors.error.default.hex}}
+--color=info:{{colors.primary.default.hex}}
+--color=pointer:{{colors.terminal_cursor.default.hex}}
+--color=marker:{{colors.on_surface_variant.default.hex}}
+--color=fg+:{{colors.on_surface.default.hex}}
+--color=prompt:{{colors.primary.default.hex}}
+--color=hl+:{{colors.error.default.hex}}
+--color=selected-bg:{{colors.terminal_normal_black.default.hex}}
+--color=border:{{colors.terminal_selection_bg.default.hex}}
+--color=label:{{colors.on_surface.default.hex}}"
+
+if set -q FZF_DEFAULT_OPTS[1]; and test -n "$FZF_DEFAULT_OPTS"
+    set -Ux FZF_DEFAULT_OPTS "$FZF_DEFAULT_OPTS
+$fzf_theme_opts"
+else
+    set -Ux FZF_DEFAULT_OPTS "$fzf_theme_opts"
+end

--- a/fzf/fzf.sh
+++ b/fzf/fzf.sh
@@ -1,0 +1,19 @@
+fzf_theme_opts="\
+--color=bg+:{{colors.surface_variant.default.hex}}
+--color=bg:{{colors.surface.default.hex}}
+--color=spinner:{{colors.terminal_cursor.default.hex}}
+--color=hl:{{colors.error.default.hex}}
+--color=fg:{{colors.terminal_foreground.default.hex}}
+--color=header:{{colors.error.default.hex}}
+--color=info:{{colors.primary.default.hex}}
+--color=pointer:{{colors.terminal_cursor.default.hex}}
+--color=marker:{{colors.on_surface_variant.default.hex}}
+--color=fg+:{{colors.on_surface.default.hex}}
+--color=prompt:{{colors.primary.default.hex}}
+--color=hl+:{{colors.error.default.hex}}
+--color=selected-bg:{{colors.terminal_normal_black.default.hex}}
+--color=border:{{colors.terminal_selection_bg.default.hex}}
+--color=label:{{colors.on_surface.default.hex}}"
+
+export FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS:+$FZF_DEFAULT_OPTS
+}$fzf_theme_opts"

--- a/fzf/template.toml
+++ b/fzf/template.toml
@@ -1,0 +1,11 @@
+[catalog.fzf]
+name = "fzf"
+category = "terminal"
+
+[templates.fzf_bash]
+input_path = "fzf.sh"
+output_path = "$XDG_CONFIG_HOME/fzf/themes/noctalia.sh"
+
+[templates.fzf_fish]
+input_path = "fzf.fish"
+output_path = "$XDG_CONFIG_HOME/fzf/themes/noctalia.fish"


### PR DESCRIPTION
This template does not include a post hook to automatically apply the theme. Since FZF theming is shell-specific and configured through environment variables, users may have very different shell setups—rather than a plain `.zshrc`, for example, some may use lazy loading or other custom initialization logic.

It is therefore better not to make that decision for users. This PR respects any existing `FZF_DEFAULT_OPTS` value and only appends the color-related options to it.

The template should generate the theme options in:

- `~/.config/fzf/themes/noctalia.sh`
- `~/.config/fzf/themes/noctalia.fish`

Users are then responsible for sourcing the appropriate file from their own shell configuration.

Because this requires manual setup, we should also add an entry to the documentation website under the **Community Templates** section. If this PR is approved, I will open a documentation PR for that shortly afterward.

Here is a demo:

<details>
<summary>Catppuccin Dark</summary>

<img width="2560" height="1440" alt="Catppuccin Dark" src="https://github.com/user-attachments/assets/fcfdfcc0-e6a4-4093-bf5c-34afaf7fe5bf" />

</details>

<details>
<summary>Nord Dark</summary>

<img width="2560" height="1440" alt="Nord Dark" src="https://github.com/user-attachments/assets/fc15d61b-6553-4ef8-a745-a835f4ab5708" />

</details>

<details>
<summary>Rosé Pine Light</summary>

<img width="2560" height="1440" alt="Rosé Pine Light" src="https://github.com/user-attachments/assets/736b4ec5-0c2c-4e14-9f23-65acaf905b0f" />


</details>
