### PR TITLE
Add qutebrowser template

### DIFF
--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -4,7 +4,7 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
 
 ## Setup
 
-**If you're using Noctalia's community-templates catalog:** just enable the `qutebrowser` template from the catalog — the repo (including `template.py` and `reload.sh`) is cloned to `~/.cache/noctalia/community-templates/` automatically, so `templates.toml` and the hook path already resolve correctly. Skip to step 3.
+**If you're using Noctalia's community-templates catalog:** just enable the `qutebrowser` template from the catalog — the repo (including `template.py` and `reload.sh`) is cloned to `~/.local/state/noctalia/community-templates/` automatically, so `templates.toml` and the hook path already resolve correctly. Skip to step 3 once you're confirmed :)
 
 **Manual / standalone setup:**
 
@@ -22,7 +22,8 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
    output_path = "~/.config/qutebrowser/noctalia/colors.py"
    post_hook   = "sh ~/.config/qutebrowser/noctalia/reload.sh"
 ```
-   (Point `post_hook` at wherever you actually placed `reload.sh` — the catalog default of `~/.cache/noctalia/community-templates/qutebrowser/reload.sh` only exists if you installed via the catalog.)
+   (Point `post_hook` at wherever you actually placed `reload.sh`. If installing via the catalog, resolve the path dynamically instead of hardcoding it, since the clone location has moved between Noctalia versions:
+   `post_hook = "sh \"${XDG_STATE_HOME:-$HOME/.local/state}/noctalia/community-templates/qutebrowser/reload.sh\""`)
 
 3. Tell qutebrowser to load the generated file by adding this line near the top of your `~/.config/qutebrowser/config.py`:
 ```python
@@ -31,9 +32,33 @@ Matugen template that themes qutebrowser (completion menu, hints, tabs, statusba
 
 4. Trigger a theme regeneration (change wallpaper, or re-select the current one) so matugen renders `template.py` into `colors.py` for the first time.
 
-That's it — no manual reload needed after the first run. The `post_hook` first checks whether qutebrowser is already running (`pgrep -x qutebrowser`); only if it finds a running instance does it send `:config-source` over qutebrowser's IPC socket to reload the new colors. If qutebrowser isn't open, the hook does nothing and won't launch a new window — so theme changes never interrupt you with an unwanted qutebrowser window popping up.
+That's it — no manual reload needed after the first run. The `post_hook` first checks whether qutebrowser is already running (`pgrep -f qutebrowser`, which matches the full command line rather than just the short process name — some installs launch qutebrowser through a wrapper, which `pgrep -x` can miss); only if it finds a running instance does it send `:config-source` over qutebrowser's IPC socket to reload the new colors. If qutebrowser isn't open, the hook does nothing and won't launch a new window — so theme changes never interrupt you with an unwanted qutebrowser window popping up. Thanks to @VuiMuich for pointing out this issue :)
 
 Your color scheme should now update automatically every time Noctalia's theme regenerates, but only while qutebrowser is actually open.
+
+> **Tip:** If you use light/dark mode switching too (which also fires a reload script on qutebrowser), the same IPC command can end up stealing window focus depending on your window manager/compositor. The fix, per a qutebrowser maintainer in [discussion #6212](https://github.com/qutebrowser/qutebrowser/discussions/6212), is to set `new_instance_open_target` to `tab-silent` in your `config.py`, so sending IPC commands to a running instance doesn't raise/focus the window:
+> ```python
+> c.new_instance_open_target = 'tab-silent'
+> ```
+> Note this is still somewhat WM/compositor-dependent — it's the known workaround, not a guaranteed fix on every setup. Thanks to @VuiMuich for flagging this one too :)
+
+### `reload.sh`
+
+```sh
+#!/bin/sh
+COLORS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/noctalia/colors.py"
+
+# Skip if colors.py hasn't changed since the last time this script ran
+[ "$COLORS_FILE" -nt "$0" ] || exit 0
+touch "$0"
+
+pgrep -f qutebrowser >/dev/null && qutebrowser :config-source
+```
+
+Make sure it's executable after copying or editing:
+```bash
+chmod +x ~/.config/qutebrowser/noctalia/reload.sh
+```
 
 ## Why a helper function is in the template
 

--- a/qutebrowser/reload.sh
+++ b/qutebrowser/reload.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 COLORS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/noctalia/colors.py"
 
+# Skip if colors.py hasn't changed
 [ "$COLORS_FILE" -nt "$0" ] || exit 0
 touch "$0"
 
-pgrep -x qutebrowser >/dev/null && qutebrowser :config-source
+pgrep -f qutebrowser >/dev/null && qutebrowser :config-source

--- a/qutebrowser/template.toml
+++ b/qutebrowser/template.toml
@@ -5,4 +5,4 @@ category = "browser"
 [templates.qutebrowser]
 input_path = "template.py"
 output_path = "$XDG_CONFIG_HOME/qutebrowser/noctalia/colors.py"
-post_hook = "sh ~/.cache/noctalia/community-templates/qutebrowser/reload.sh"
+post_hook = "sh \"${XDG_STATE_HOME:-$HOME/.local/state}/noctalia/community-templates/qutebrowser/reload.sh\""


### PR DESCRIPTION
Fixes two things surfaced by users after the template shipped: `pgrep -x` was unreliably detecting a running qutebrowser instance on some setups (some installs launch through a wrapper, so the short process name `pgrep -x` matches against isn't always `qutebrowser`), and the catalog's default `post_hook` path was hardcoded to `~/.cache/...` even though newer Noctalia versions clone community-templates to `~/.local/state/...` instead. Also adds a README tip for light/dark switchers about a related IPC focus-stealing issue.

Thanks to @VuiMuich for flagging both the `pgrep` detection issue and the IPC focus-stealing behavior with light/dark switching.

## Template
- **App:** qutebrowser
- **Template id (directory):** `qutebrowser`
- [ ] New template
- [x] Update to an existing template

## What it themes
No change to what's themed. This only touches `reload.sh` and the README:

- `reload.sh` now checks for a running instance with `pgrep -f qutebrowser` instead of `pgrep -x qutebrowser`, since `-x` matches on the short process name only and can miss a genuinely running instance depending on how qutebrowser was launched.
- The catalog setup instructions and the fallback `post_hook` example now resolve the community-templates clone path dynamically (`${XDG_STATE_HOME:-$HOME/.local/state}/...`) instead of hardcoding `~/.cache/...`, since the clone location has moved between Noctalia versions.
- Added a README tip for anyone also using light/dark theme switching: the same IPC `:config-source` call can steal window focus depending on WM/compositor, and setting `new_instance_open_target = 'tab-silent'` in `config.py` is the known workaround (per qutebrowser discussion #6212).

## Testing
- **App version tested:** qutebrowser 3.7.0
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

Also confirmed: `pgrep -f qutebrowser` correctly finds a running instance in cases where `pgrep -x qutebrowser` returned nothing, so `:config-source` now fires reliably instead of silently no-op'ing.

## Hooks
- **What the hook does:** checks if `colors.py` is newer than the script's own last-run timestamp (from the earlier idempotency fix in #89); if so, checks if qutebrowser is running via `pgrep -f qutebrowser`, and if it is, sends `:config-source` over IPC to reload the newly generated colors. If qutebrowser isn't running, the hook exits without opening a new window.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [ ] It fails loudly (non-zero exit, message on stderr) when the app's config is missing. — Not applicable in the traditional sense: if `config.py` or `colors.py` has an error, qutebrowser surfaces it as an in-app red error banner rather than a stderr message, since `:config-source` runs inside the browser's own process, not as a standalone script.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist
- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.