### PR TITLE
Fix: QuteBrowser Tabs Theming and Fixing

### DIFF
--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -2,9 +2,7 @@
 
 Matugen template that themes qutebrowser (completion menu, hints, tabs, statusbar, prompts, messages, downloads bar) to match your current Noctalia color scheme.
 
-> Note: Some palettes don't work really well with the theming. Some built-in themes, like Noctalia (dark) give you unreadable foreground tab color after the script runs the QB theme. Some wallpaper palettes like yellow (dark) and blue (light) give you the same issue. One of the fix that I thought was that you can give the tabs same color as pinned tabs across all themes, but then again it won't provide you a good look with vertical tabs or it'll get too bright for the dark-mode users (whom I honestly don't want to piss, lol :3). But I am hopeful that most of the community-palettes should work.
-
-> If in any case you really want to change the colors, then you can always go to the **Tabs** section (search for `## Tabs`) in `template.py` and edit the values of **Selected/Unselected Foreground/Background Even/Odd** tabs. I hope I find a workaround in the future and push the update or somehow get possessed by a ghost with good design knowledge so that I can fix it. But for now, this has to be done manually, and for that I am sorry :/
+> Note: Some palettes might not work well or as intended. Please change the color scheme or try out a different template then. Else you can go to `~/.config/qutebrowser/noctalia/template.py` and tweak the colors yourself.
 
 ## Setup
 

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -2,6 +2,10 @@
 
 Matugen template that themes qutebrowser (completion menu, hints, tabs, statusbar, prompts, messages, downloads bar) to match your current Noctalia color scheme.
 
+> Note: Some palettes don't work really well with the theming. Some built-in themes, like Noctalia (dark) give you unreadable foreground tab color after the script runs the QB theme. Some wallpaper palettes like yellow (dark) and blue (light) give you the same issue. One of the fix that I thought was that you can give the tabs same color as pinned tabs across all themes, but then again it won't provide you a good look with vertical tabs or it'll get too bright for the dark-mode users (whom I honestly don't want to piss, lol :3). But I am hopeful that most of the community-palettes should work.
+
+> If in any case you really want to change the colors, then you can always go to the **Tabs** section (search for `## Tabs`) in `template.py` and edit the values of **Selected/Unselected Foreground/Background Even/Odd** tabs. I hope I find a workaround in the future and push the update or somehow get possessed by a ghost with good design knowledge so that I can fix it. But for now, this has to be done manually, and for that I am sorry :/
+
 ## Setup
 
 **If you're using Noctalia's community-templates catalog:** just enable the `qutebrowser` template from the catalog — the repo (including `template.py` and `reload.sh`) is cloned to `~/.local/state/noctalia/community-templates/` automatically, so `templates.toml` and the hook path already resolve correctly. Skip to step 3 once you're confirmed :)
@@ -82,3 +86,12 @@ This has to live in `template.py` itself, not in the generated `colors.py`. Sinc
 - Tested with qutebrowser v3.7.0 / QtWebEngine 6.11.
 
 > **Tip:** `:config-source` re-runs your entire `config.py` from top to bottom, not just the colors. If `config.load_autoconfig(True)` is called near the *top* of your `config.py`, any settings you toggle at runtime (`:config-cycle`, `:set`, etc. — saved to `autoconfig.yml`) will get overwritten by whatever hardcoded values come after it in the file, resetting things like dark mode or tab position back to your defaults every time the theme regenerates. Move `config.load_autoconfig(True)` to the **bottom** of `config.py`, after all your other settings, so your current session state loads last and wins.
+
+> Also if you're using Niri, you might have to put this in your `rules.kdl` as well... (DISCLAIMER: won't work in `niri 26.04` version, to check your Niri version use `niri --version`)
+```kdl
+// --- QuteBrowser ---
+window-rule {
+match app-id="org.qutebrowser.qutebrowser"
+focus-on-xdg-activate false
+}
+```

--- a/qutebrowser/template.py
+++ b/qutebrowser/template.py
@@ -245,37 +245,37 @@ c.colors.tabs.indicator.stop = secondary
 # Color for the tab indicator on errors.
 c.colors.tabs.indicator.error = error
 # Foreground color of unselected odd tabs.
-c.colors.tabs.odd.fg = hex_to_rgba(secondary, 0.9)
+c.colors.tabs.odd.fg = hex_to_rgba(on_primary_container, 0.6)
 # Background color of unselected odd tabs.
-c.colors.tabs.odd.bg = hex_to_rgba(surface_container_high, 1.0)
+c.colors.tabs.odd.bg = hex_to_rgba(primary_container, 1.0)
 # Foreground color of unselected even tabs.
-c.colors.tabs.even.fg = hex_to_rgba(secondary, 0.9)
+c.colors.tabs.even.fg = hex_to_rgba(on_primary_container, 0.6)
 # Background color of unselected even tabs.
-c.colors.tabs.even.bg = hex_to_rgba(surface_container_high, 1.0)
+c.colors.tabs.even.bg = hex_to_rgba(primary_container, 1.0)
 # Foreground color of selected odd tabs.
-c.colors.tabs.selected.odd.fg = on_primary_container
+c.colors.tabs.selected.odd.fg = primary
 # Background color of selected odd tabs.
 c.colors.tabs.selected.odd.bg = hex_to_rgba(primary_container, 0.4)
 # Foreground color of selected even tabs.
-c.colors.tabs.selected.even.fg = on_primary_container
+c.colors.tabs.selected.even.fg = primary
 # Background color of selected even tabs.
 c.colors.tabs.selected.even.bg = hex_to_rgba(primary_container, 0.4)
 # Foreground color of pinned unselected odd tabs.
-c.colors.tabs.pinned.odd.fg = hex_to_rgba(on_secondary, 1.0)
+c.colors.tabs.pinned.odd.fg = hex_to_rgba(on_tertiary_container, 0.6)
 # Background color of pinned unselected odd tabs.
-c.colors.tabs.pinned.odd.bg = hex_to_rgba(secondary, 0.8)
+c.colors.tabs.pinned.odd.bg = hex_to_rgba(tertiary_container, 1.0)
 # Foreground color of pinned unselected even tabs.
-c.colors.tabs.pinned.even.fg = hex_to_rgba(on_secondary, 1.0)
+c.colors.tabs.pinned.even.fg = hex_to_rgba(on_tertiary_container, 0.6)
 # Background color of pinned unselected even tabs.
-c.colors.tabs.pinned.even.bg = hex_to_rgba(secondary, 0.8)
+c.colors.tabs.pinned.even.bg = hex_to_rgba(tertiary_container, 1.0)
 # Foreground color of pinned selected odd tabs.
-c.colors.tabs.pinned.selected.odd.fg = on_primary_container
+c.colors.tabs.pinned.selected.odd.fg = tertiary
 # Background color of pinned selected odd tabs.
-c.colors.tabs.pinned.selected.odd.bg = hex_to_rgba(primary_container, 0.4)
+c.colors.tabs.pinned.selected.odd.bg = hex_to_rgba(tertiary_container, 0.4)
 # Foreground color of pinned selected even tabs.
-c.colors.tabs.pinned.selected.even.fg = on_primary_container
+c.colors.tabs.pinned.selected.even.fg = tertiary
 # Background color of pinned selected even tabs.
-c.colors.tabs.pinned.selected.even.bg = hex_to_rgba(primary_container, 0.4)
+c.colors.tabs.pinned.selected.even.bg = hex_to_rgba(tertiary_container, 0.4)
 
 # Background color for webpages if unset (or empty to use the theme's color).
 c.colors.webpage.bg = surface

--- a/qutebrowser/template.py
+++ b/qutebrowser/template.py
@@ -67,52 +67,37 @@ def hex_to_rgba(hex_color, alpha):
     b = int(hex_color[4:6], 16)
     return 'rgba({}, {}, {}, {})'.format(r, g, b, alpha)
 
-
 ### Completion
 
 # Text color of the completion widget. May be a single color to use for
 # all columns or a list of three colors, one for each column.
 c.colors.completion.fg = [on_surface, primary, tertiary]
-
 # Background color of the completion widget for odd rows.
 c.colors.completion.odd.bg = surface_container
-
 # Background color of the completion widget for even rows.
 c.colors.completion.even.bg = surface_container_low
-
 # Foreground color of completion widget category headers.
 c.colors.completion.category.fg = primary
-
 # Background color of the completion widget category headers.
 c.colors.completion.category.bg = surface_container_high
-
 # Top border color of the completion widget category headers.
 c.colors.completion.category.border.top = outline_variant
-
 # Bottom border color of the completion widget category headers.
 c.colors.completion.category.border.bottom = outline_variant
-
 # Foreground color of the selected completion item.
 c.colors.completion.item.selected.fg = on_primary_container
-
 # Background color of the selected completion item.
 c.colors.completion.item.selected.bg = primary_container
-
 # Top border color of the selected completion item.
 c.colors.completion.item.selected.border.top = primary_container
-
 # Bottom border color of the selected completion item.
 c.colors.completion.item.selected.border.bottom = primary_container
-
 # Foreground color of the matched text in the selected completion item.
 c.colors.completion.item.selected.match.fg = tertiary
-
 # Foreground color of the matched text in the completion.
 c.colors.completion.match.fg = tertiary
-
 # Color of the scrollbar handle in the completion view.
 c.colors.completion.scrollbar.fg = primary
-
 # Color of the scrollbar in the completion view.
 c.colors.completion.scrollbar.bg = surface_variant
 
@@ -120,19 +105,14 @@ c.colors.completion.scrollbar.bg = surface_variant
 
 # Background color of disabled items in the context menu.
 c.colors.contextmenu.disabled.bg = surface_variant
-
 # Foreground color of disabled items in the context menu.
 c.colors.contextmenu.disabled.fg = on_surface_variant
-
 # Background color of the context menu. If set to null, the Qt default is used.
 c.colors.contextmenu.menu.bg = surface_container
-
 # Foreground color of the context menu. If set to null, the Qt default is used.
 c.colors.contextmenu.menu.fg = on_surface
-
 # Background color of the context menu's selected item. If set to null, the Qt default is used.
 c.colors.contextmenu.selected.bg = secondary_container
-
 # Foreground color of the context menu's selected item. If set to null, the Qt default is used.
 c.colors.contextmenu.selected.fg = on_secondary_container
 
@@ -140,19 +120,14 @@ c.colors.contextmenu.selected.fg = on_secondary_container
 
 # Background color for the download bar.
 c.colors.downloads.bar.bg = surface
-
 # Color gradient start for download text.
 c.colors.downloads.start.fg = on_primary
-
 # Color gradient start for download backgrounds.
 c.colors.downloads.start.bg = primary
-
 # Color gradient end for download text.
 c.colors.downloads.stop.fg = on_secondary
-
 # Color gradient stop for download backgrounds.
 c.colors.downloads.stop.bg = secondary
-
 # Foreground color for downloads with errors.
 c.colors.downloads.error.fg = error
 
@@ -160,16 +135,12 @@ c.colors.downloads.error.fg = error
 
 # Font color for hints.
 c.colors.hints.fg = primary
-
 # Background color for hints.
 c.colors.hints.bg = hex_to_rgba(on_primary, 0.7)
-
 # Font color for the matched part of hints.
 c.colors.hints.match.fg = on_primary_container
-
 # Border around hint labels.
 c.hints.border = f'1px solid {primary}'
-
 # Corner rounding for hint labels.
 c.hints.radius = 1
 
@@ -177,10 +148,8 @@ c.hints.radius = 1
 
 # Text color for the keyhint widget.
 c.colors.keyhint.fg = on_surface_variant
-
 # Highlight color for keys to complete the current keychain.
 c.colors.keyhint.suffix.fg = primary
-
 # Background color of the keyhint widget.
 c.colors.keyhint.bg = surface_container
 
@@ -188,28 +157,20 @@ c.colors.keyhint.bg = surface_container
 
 # Foreground color of an error message.
 c.colors.messages.error.fg = on_error
-
 # Background color of an error message.
 c.colors.messages.error.bg = error
-
 # Border color of an error message.
 c.colors.messages.error.border = error
-
 # Foreground color of a warning message.
 c.colors.messages.warning.fg = on_error_container
-
 # Background color of a warning message.
 c.colors.messages.warning.bg = error_container
-
 # Border color of a warning message.
 c.colors.messages.warning.border = error_container
-
 # Foreground color of an info message.
 c.colors.messages.info.fg = on_surface
-
 # Background color of an info message.
 c.colors.messages.info.bg = surface_container
-
 # Border color of an info message.
 c.colors.messages.info.border = outline
 
@@ -217,13 +178,10 @@ c.colors.messages.info.border = outline
 
 # Foreground color for prompts.
 c.colors.prompts.fg = on_surface
-
 # Border used around UI elements in prompts.
 c.colors.prompts.border = f'1px solid {outline}'
-
 # Background color for prompts.
 c.colors.prompts.bg = surface_container_high
-
 # Background color for the selected item in filename prompts.
 c.colors.prompts.selected.bg = secondary_container
 
@@ -231,134 +189,93 @@ c.colors.prompts.selected.bg = secondary_container
 
 # Foreground color of the statusbar.
 c.colors.statusbar.normal.fg = on_surface
-
 # Background color of the statusbar.
 c.colors.statusbar.normal.bg = surface
-
 # Foreground color of the statusbar in insert mode.
 c.colors.statusbar.insert.fg = on_primary
-
 # Background color of the statusbar in insert mode.
 c.colors.statusbar.insert.bg = primary
-
 # Foreground color of the statusbar in passthrough mode.
 c.colors.statusbar.passthrough.fg = on_secondary
-
 # Background color of the statusbar in passthrough mode.
 c.colors.statusbar.passthrough.bg = secondary
-
 # Foreground color of the statusbar in private browsing mode.
 c.colors.statusbar.private.fg = tertiary
-
 # Background color of the statusbar in private browsing mode.
 c.colors.statusbar.private.bg = surface
-
 # Foreground color of the statusbar in command mode.
 c.colors.statusbar.command.fg = on_surface
-
 # Background color of the statusbar in command mode.
 c.colors.statusbar.command.bg = surface_container
-
 # Foreground color of the statusbar in private browsing + command mode.
 c.colors.statusbar.command.private.fg = tertiary
-
 # Background color of the statusbar in private browsing + command mode.
 c.colors.statusbar.command.private.bg = surface_container
-
 # Foreground color of the statusbar in caret mode.
 c.colors.statusbar.caret.fg = on_tertiary
-
 # Background color of the statusbar in caret mode.
 c.colors.statusbar.caret.bg = tertiary
-
 # Foreground color of the statusbar in caret mode with a selection.
 c.colors.statusbar.caret.selection.fg = on_tertiary_container
-
 # Background color of the statusbar in caret mode with a selection.
 c.colors.statusbar.caret.selection.bg = tertiary_container
-
 # Background color of the progress bar.
 c.colors.statusbar.progress.bg = primary
-
 # Default foreground color of the URL in the statusbar.
 c.colors.statusbar.url.fg = on_surface_variant
-
 # Foreground color of the URL in the statusbar on error.
 c.colors.statusbar.url.error.fg = error
-
 # Foreground color of the URL in the statusbar for hovered links.
 c.colors.statusbar.url.hover.fg = primary
-
 # Foreground color of the URL in the statusbar on successful load (http).
 c.colors.statusbar.url.success.http.fg = error
-
 # Foreground color of the URL in the statusbar on successful load (https).
 c.colors.statusbar.url.success.https.fg = secondary
-
 # Foreground color of the URL in the statusbar when there's a warning.
 c.colors.statusbar.url.warn.fg = tertiary
 
-### Tabs
+### ---Tabs ---
 
 # Background color of the tab bar.
-c.colors.tabs.bar.bg = hex_to_rgba(surface, 1)
-
+c.colors.tabs.bar.bg = hex_to_rgba(surface, 1.0)
 # Color gradient start for the tab indicator.
 c.colors.tabs.indicator.start = primary
-
 # Color gradient end for the tab indicator.
 c.colors.tabs.indicator.stop = secondary
-
 # Color for the tab indicator on errors.
 c.colors.tabs.indicator.error = error
-
 # Foreground color of unselected odd tabs.
-c.colors.tabs.odd.fg = on_surface_variant
-
+c.colors.tabs.odd.fg = hex_to_rgba(secondary, 0.9)
 # Background color of unselected odd tabs.
-c.colors.tabs.odd.bg = hex_to_rgba(surface_container, 1)
-
+c.colors.tabs.odd.bg = hex_to_rgba(surface_container_high, 1.0)
 # Foreground color of unselected even tabs.
-c.colors.tabs.even.fg = on_surface_variant
-
+c.colors.tabs.even.fg = hex_to_rgba(secondary, 0.9)
 # Background color of unselected even tabs.
-c.colors.tabs.even.bg = hex_to_rgba(surface_container_high, 1)
-
+c.colors.tabs.even.bg = hex_to_rgba(surface_container_high, 1.0)
 # Foreground color of selected odd tabs.
 c.colors.tabs.selected.odd.fg = on_primary_container
-
 # Background color of selected odd tabs.
-c.colors.tabs.selected.odd.bg = hex_to_rgba(primary_container, 1)
-
+c.colors.tabs.selected.odd.bg = hex_to_rgba(primary_container, 0.4)
 # Foreground color of selected even tabs.
 c.colors.tabs.selected.even.fg = on_primary_container
-
 # Background color of selected even tabs.
-c.colors.tabs.selected.even.bg = hex_to_rgba(primary_container, 1)
-
-# Background color of pinned unselected even tabs.
-c.colors.tabs.pinned.even.bg = hex_to_rgba(secondary_container, 1)
-
-# Foreground color of pinned unselected even tabs.
-c.colors.tabs.pinned.even.fg = on_secondary_container
-
-# Background color of pinned unselected odd tabs.
-c.colors.tabs.pinned.odd.bg = hex_to_rgba(secondary_container, 1)
-
+c.colors.tabs.selected.even.bg = hex_to_rgba(primary_container, 0.4)
 # Foreground color of pinned unselected odd tabs.
-c.colors.tabs.pinned.odd.fg = on_secondary_container
-
-# Background color of pinned selected even tabs.
-c.colors.tabs.pinned.selected.even.bg = hex_to_rgba(primary_container, 1)
-
-# Foreground color of pinned selected even tabs.
-c.colors.tabs.pinned.selected.even.fg = on_primary_container
-
-# Background color of pinned selected odd tabs.
-c.colors.tabs.pinned.selected.odd.bg = hex_to_rgba(primary_container, 1)
-
+c.colors.tabs.pinned.odd.fg = hex_to_rgba(on_secondary, 1.0)
+# Background color of pinned unselected odd tabs.
+c.colors.tabs.pinned.odd.bg = hex_to_rgba(secondary, 0.8)
+# Foreground color of pinned unselected even tabs.
+c.colors.tabs.pinned.even.fg = hex_to_rgba(on_secondary, 1.0)
+# Background color of pinned unselected even tabs.
+c.colors.tabs.pinned.even.bg = hex_to_rgba(secondary, 0.8)
 # Foreground color of pinned selected odd tabs.
 c.colors.tabs.pinned.selected.odd.fg = on_primary_container
+# Background color of pinned selected odd tabs.
+c.colors.tabs.pinned.selected.odd.bg = hex_to_rgba(primary_container, 0.4)
+# Foreground color of pinned selected even tabs.
+c.colors.tabs.pinned.selected.even.fg = on_primary_container
+# Background color of pinned selected even tabs.
+c.colors.tabs.pinned.selected.even.bg = hex_to_rgba(primary_container, 0.4)
 
 # Background color for webpages if unset (or empty to use the theme's color).
 c.colors.webpage.bg = surface


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** <!-- e.g. Fuzzel -->
- **Template id (directory):** `qutebrowser`
- [ ] New template
- [x] Update to an existing template

## What it themes

<!-- Which config file(s) of the app get rendered, and what the user sees change. -->

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** <!-- e.g. fuzzel 1.11.0 -->
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

Light Mode:

<img width="1540" height="878" alt="image" src="https://github.com/user-attachments/assets/76096790-8268-4463-92ec-f94956456889" />

Dark Mode:

<img width="1540" height="878" alt="image" src="https://github.com/user-attachments/assets/7c696f5b-0f40-4b12-a93b-12a7544286d0" />



<!-- The app running with the theme applied. Required. -->

## Hooks

<!-- Skip this section if the template has no pre_hook or post_hook. -->

- **What the hook does:** <!-- e.g. rewrites `theme = "..."` in the app's config so it points at the rendered file -->
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [ ] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
