### PR TITLE
fix(Zed): improve readability for the light theme(s)

### DIFF
--- a/zed/zed.json
+++ b/zed/zed.json
@@ -495,7 +495,7 @@
             "font_weight": null
           },
           "number": {
-            "color": "{{colors.tertiary_fixed.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -515,7 +515,7 @@
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "{{colors.secondary_fixed.light.hex}}",
+            "color": "{{colors.on_secondary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -540,12 +540,12 @@
             "font_weight": null
           },
           "string.escape": {
-            "color": "{{colors.tertiary_fixed_dim.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
-            "color": "{{colors.tertiary_fixed.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -570,7 +570,7 @@
             "font_weight": null
           },
           "type": {
-            "color": "{{colors.primary_fixed.light.hex}}",
+            "color": "{{colors.on_primary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -1079,7 +1079,7 @@
             "font_weight": null
           },
           "number": {
-            "color": "{{colors.tertiary_fixed.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -1099,7 +1099,7 @@
             "font_weight": null
           },
           "punctuation.bracket": {
-            "color": "{{colors.secondary_fixed.light.hex}}",
+            "color": "{{colors.on_secondary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -1124,12 +1124,12 @@
             "font_weight": null
           },
           "string.escape": {
-            "color": "{{colors.tertiary_fixed_dim.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
           "string.regex": {
-            "color": "{{colors.tertiary_fixed.light.hex}}",
+            "color": "{{colors.on_tertiary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },
@@ -1154,7 +1154,7 @@
             "font_weight": null
           },
           "type": {
-            "color": "{{colors.primary_fixed.light.hex}}",
+            "color": "{{colors.on_primary_container.light.hex}}",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
## Template

- **App:** Zed
- **Template id (directory):** `community-templates/zed/`
- [ ] New template
- [x] Update to an existing template

## What it themes
 
All of the Zed editor UI.

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** Zed 1.14.2
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

readability before this fix:
<img width="384" height="122" alt="grafik" src="https://github.com/user-attachments/assets/0b7305e9-89f3-420d-9edf-77a54fed3122" />

readability after this fix:
<img width="388" height="130" alt="grafik" src="https://github.com/user-attachments/assets/1060b5b1-9bc7-4258-bc73-b31de72691ef" />

that goes for transparent and non-transparent variants of the theme.

## Hooks

(unchanged / none, just places the .json file where it needs to be)

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
