### PR TITLE
Add halloy template

### DIFF
--- a/halloy/apply.sh
+++ b/halloy/apply.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_file="${XDG_CONFIG_HOME:-$HOME/.config}/halloy/config.toml"
+
+if [ ! -f "$config_file" ]; then
+  echo "Error: halloy config file not found at $config_file" >&2
+  exit 1
+fi
+
+write_if_changed() {
+  local target="$1" tmp="$2"
+  if ! cmp -s "$target" "$tmp"; then
+    cat "$tmp" >"$target"
+  fi
+  rm -f "$tmp"
+}
+
+# `theme` is a root key: it must appear before the first [section] header,
+# so all matching/rewriting below is confined to that root region.
+if awk '/^\[/ { exit 1 } /^theme[[:space:]]*=[[:space:]]*"noctalia"[[:space:]]*(#.*)?$/ { found = 1 } END { exit !found }' "$config_file"; then
+  : # already set
+elif awk '/^\[/ { exit 1 } /^theme[[:space:]]*=/ { found = 1 } END { exit !found }' "$config_file"; then
+  # A root-level theme key exists with a different value: replace it in place.
+  tmp_file="$(mktemp "${config_file}.tmp.XXXXXX")"
+  awk '
+    /^\[/ { in_section = 1 }
+    !in_section && /^theme[[:space:]]*=/ { print "theme = \"noctalia\""; next }
+    { print }
+  ' "$config_file" >"$tmp_file"
+  write_if_changed "$config_file" "$tmp_file"
+else
+  # No root-level theme key: insert one before the first section header,
+  # or append at the end if the file has no sections at all.
+  tmp_file="$(mktemp "${config_file}.tmp.XXXXXX")"
+  awk '
+    /^\[/ && !inserted { print "theme = \"noctalia\""; print ""; inserted = 1 }
+    { print }
+    END { if (!inserted) print "theme = \"noctalia\"" }
+  ' "$config_file" >"$tmp_file"
+  write_if_changed "$config_file" "$tmp_file"
+fi
+
+pkill -SIGUSR1 halloy >/dev/null 2>&1 || true

--- a/halloy/halloy.toml
+++ b/halloy/halloy.toml
@@ -1,0 +1,48 @@
+[general]
+background = "{{colors.background.default.hex}}"
+border = "{{colors.surface_container_high.default.hex}}"
+horizontal_rule = "{{colors.primary.default.hex}}"
+scrollbar = "{{colors.outline_variant.default.hex}}"
+unread_indicator = "{{colors.secondary.default.hex}}"
+highlight_indicator = "{{colors.tertiary.default.hex}}"
+
+[text]
+primary = "{{colors.on_surface.default.hex}}"
+secondary = "{{colors.on_surface_variant.default.hex}}"
+tertiary = "{{colors.on_surface.default.hex}}"
+success = "{{colors.tertiary.default.hex}}"
+error = "{{colors.error.default.hex}}"
+warning = "{{colors.secondary.default.hex}}"
+info = "{{colors.primary.default.hex}}"
+debug = "{{colors.outline.default.hex}}"
+trace = "{{colors.outline_variant.default.hex}}"
+
+[buffer]
+action = "{{colors.tertiary.default.hex}}"
+background = "{{colors.surface.default.hex}}"
+background_text_input = "{{colors.surface_container.default.hex}}"
+background_title_bar = "{{colors.surface_container_lowest.default.hex}}"
+border = "{{colors.outline_variant.default.hex}}"
+border_selected = "{{colors.primary.default.hex}}"
+code = "{{colors.on_surface_variant.default.hex}}"
+highlight = "{{colors.secondary.default.hex}}"
+nickname = "{{colors.primary.default.hex}}"
+selection = "{{colors.primary.default.hex | set_alpha 0.2}}"
+timestamp = "{{colors.outline.default.hex}}"
+topic = "{{colors.secondary.default.hex}}"
+url = "{{colors.tertiary.default.hex}}"
+
+[buffer.server_messages]
+default = "{{colors.outline.default.hex}}"
+
+[buttons.primary]
+background = "{{colors.surface_container_low.default.hex}}"
+background_hover = "{{colors.surface_container.default.hex}}"
+background_selected = "{{colors.surface_container_high.default.hex}}"
+background_selected_hover = "{{colors.surface_container_highest.default.hex}}"
+
+[buttons.secondary]
+background = "{{colors.surface_container_low.default.hex}}"
+background_hover = "{{colors.surface_container.default.hex}}"
+background_selected = "{{colors.surface_container_high.default.hex}}"
+background_selected_hover = "{{colors.surface_container_highest.default.hex}}"

--- a/halloy/template.toml
+++ b/halloy/template.toml
@@ -1,0 +1,8 @@
+[catalog.halloy]
+name = "halloy"
+category = "chat"
+
+[templates.halloy]
+input_path = "halloy.toml"
+output_path = "$XDG_CONFIG_HOME/halloy/themes/noctalia.toml"
+post_hook = "bash '{{ config_dir }}/apply.sh'"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** Halloy
- **Template id (directory):** `halloy`
- [x] New template
- [ ] Update to an existing template

## What it themes

<!-- Which config file(s) of the app get rendered, and what the user sees change. -->
Renders the theme to `$XDG_CONFIG_HOME/halloy/themes/noctalia.toml`. The `theme = "noctalia"` is then **prepended** to the `$XDG_CONFIG_HOME/halloy/config.toml` instead of being appended as it is a root key and must appear at the top of the config as per the [Halloy docs](https://halloy.chat/configuration/themes).

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** halloy 2026.8
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- The app running with the theme applied. Required. -->
### Dark
<img width="944" height="886" alt="Screenshot from 2026-08-19 17-41-25" src="https://github.com/user-attachments/assets/9a54c08b-0fa5-412e-b8e3-43b49bed9798" />

### Light
<img width="944" height="886" alt="Screenshot from 2026-08-19 17-46-47" src="https://github.com/user-attachments/assets/a9e08c80-c253-49e6-aea6-235bb2b1e4bd" />

## Hooks

<!-- Skip this section if the template has no pre_hook or post_hook. -->

- **What the hook does:** If necessary, rewrites `theme = "noctalia"` in the app's config so it points at the rendered file.  `SIGUSR1` is then sent to `halloy` which causes it to re-read the config, applying the updated theme.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
