### PR TITLE
feat: add WhiteSur icon theme template

### DIFF
--- a/whitesur-icons/.gitignore
+++ b/whitesur-icons/.gitignore
@@ -1,0 +1,2 @@
+.noctalia-cache.json
+colors-final

--- a/whitesur-icons/README.md
+++ b/whitesur-icons/README.md
@@ -1,0 +1,5 @@
+# WhiteSur Icons — Noctalia Community Template
+
+Applies the closest color from the WhiteSur icon palette to match the Noctalia wallpaper-derived theme.
+
+WhiteSur icon theme installed via your package manager is currently required.

--- a/whitesur-icons/apply.sh
+++ b/whitesur-icons/apply.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# WhiteSur folder icons — dynamic color template for Noctalia.
+# Thin wrapper: reads colors-final, finds the closest WhiteSur palette
+# color to the target, then delegates to whitesur-folders for the
+# actual overlay work.
+set -euo pipefail
+
+CONFIG_DIR="$(cd "$(dirname "$0")" && pwd)"
+COLOR_FILE="$CONFIG_DIR/colors-final"
+
+[[ -f "$COLOR_FILE" ]] || exit 0
+
+mapfile -t lines <"$COLOR_FILE"
+TARGET="${lines[0]//[# ]/}"
+[[ ${#TARGET} -ge 6 ]] || exit 0
+TARGET="${TARGET:0:6}"
+TR=$((16#${TARGET:0:2}))
+TG=$((16#${TARGET:2:2}))
+TB=$((16#${TARGET:4:2}))
+
+MAPPING="$(printf '%s\n' "${lines[@]}" | sed '/^[[:space:]]*$/d' | tail -n1)"
+
+# HSV closest-color, hue-family aware (same intent as papirus-icons),
+# in a single awk pass — no bc, no extra subshells for the override step.
+closest=$(awk -v r="$TR" -v g="$TG" -v b="$TB" -v m="$MAPPING" '
+function hex2dec(h,   i,c,v,digits) {
+	digits = "0123456789abcdef"
+	h = tolower(h)
+	v = 0
+	for (i=1; i<=length(h); i++) v = v*16 + (index(digits, substr(h,i,1)) - 1)
+	return v
+}
+function rgb2hsv(r,g,b,  mx,mn,d,h,s,v,t) {
+	r/=255; g/=255; b/=255
+	mx=(r>g)?(r>b?r:b):(g>b?g:b); mn=(r<g)?(r<b?r:b):(g<b?g:b)
+	v=mx; d=mx-mn
+	if (d==0) { s=0; h=0 }
+	else {
+		s=d/mx
+		if (mx==r) { t=(g-b)/d; if(t<0) t+=6; h=60*t }
+		else if (mx==g) { h=60*(((b-r)/d)+2) }
+		else { h=60*(((r-g)/d)+4) }
+	}
+	return h SUBSEP s SUBSEP v
+}
+function family(h,s) {
+	if (s<0.1)          return "neutral"
+	if (h>=340||h<20)   return "red"
+	if (h>=20&&h<50)    return "warm"
+	if (h>=50&&h<180)   return "green"
+	if (h>=180&&h<260)  return "blue"
+	if (h>=260&&h<310)  return "cool"
+	if (h>=310&&h<340)  return "pink"
+	return "neutral"
+}
+BEGIN {
+	WH=10; WS=1; WV=0.3
+	split(rgb2hsv(r,g,b), tgt, SUBSEP)
+	th=tgt[1]+0; ts=tgt[2]+0; tv=tgt[3]+0
+	tf = family(th, ts)   # target family — now saturation-aware, so a
+	                       # near-gray target is never bucketed into a
+	                       # noisy/unstable hue family (fixes an edge
+	                       # case the original bc-based version had).
+
+	n = split(m, arr)
+	for (i=1; i<=n; i++) {
+		split(arr[i], p, ":")
+		cr=hex2dec(substr(p[2],1,2))
+		cg=hex2dec(substr(p[2],3,2))
+		cb=hex2dec(substr(p[2],5,2))
+		split(rgb2hsv(cr,cg,cb), c, SUBSEP)
+		ch=c[1]+0; cs=c[2]+0; cv=c[3]+0
+
+		dh=th-ch; if(dh<0) dh=-dh
+		if(dh>180) dh=360-dh; dh/=180
+		ds=ts-cs; dv=tv-cv
+		d = WH*(ts*cs)*dh*dh + WS*ds*ds + WV*dv*dv
+
+		if (min=="" || d<min) { min=d; best=p[1] }
+		if (family(ch,cs)==tf && (fmin=="" || d<fmin)) { fmin=d; fbest=p[1] }
+	}
+	# Prefer the nearest candidate that shares the targets hue family;
+	# fall back to the plain nearest match when the target is neutral
+	# or no candidate shares its family. Mirrors the original
+	# override-only-when-chromatic-and-mismatched behavior.
+	print (tf != "neutral" && fbest != "" ? fbest : best)
+}')
+
+# Invoked via bash so this keeps working even if a git checkout or zip
+# download drops the executable bit on whitesur-folders.
+exec bash "$CONFIG_DIR/whitesur-folders" "$closest"

--- a/whitesur-icons/colors
+++ b/whitesur-icons/colors
@@ -1,0 +1,3 @@
+{{ colors.source_color.default.hex }}
+
+green:b3ee96 grey:8f8f8f orange:ffae70 pink:ff85bd purple:e791f3 red:ff8180 yellow:ffd485 blue:46a2d7

--- a/whitesur-icons/template.toml
+++ b/whitesur-icons/template.toml
@@ -1,0 +1,8 @@
+[catalog.whitesur-icons]
+name = "WhiteSur Icon Theme"
+category = "system"
+
+[templates.whitesur_icons]
+input_path = "colors"
+output_path = "colors-final"
+post_hook = "bash '{{ config_dir }}/apply.sh'"

--- a/whitesur-icons/whitesur-folders
+++ b/whitesur-icons/whitesur-folders
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# whitesur-folders — apply a WhiteSur folder color to the icon overlay.
+# Called by apply.sh with a color name (green, grey, orange, pink, purple, red, yellow, blue).
+set -euo pipefail
+
+COLOR="${1:?Usage: whitesur-folders <color>}"
+
+# WhiteSur palette hex values
+color_hex() {
+  case "$1" in
+  green) echo b3ee96 ;;
+  grey) echo 8f8f8f ;;
+  orange) echo ffae70 ;;
+  pink) echo ff85bd ;;
+  purple) echo e791f3 ;;
+  red) echo ff8180 ;;
+  yellow) echo ffd485 ;;
+  blue) echo 46a2d7 ;;
+  esac
+}
+
+# Compute dark / main / medium / light HSV variants. Prints 4 hex lines.
+color_variants() {
+  local hex="$1"
+  local r g b
+  r=$((16#${hex:0:2}))
+  g=$((16#${hex:2:2}))
+  b=$((16#${hex:4:2}))
+  awk -v r=$r -v g=$g -v b=$b '
+function rgb2hsv(r,g,b,  mx,mn,d,h,s,v,t) {
+	r/=255; g/=255; b/=255
+	mx=(r>g)?(r>b?r:b):(g>b?g:b); mn=(r<g)?(r<b?r:b):(g<b?g:b)
+	v=mx; d=mx-mn
+	if(d==0){s=0;h=0} else { s=d/mx
+		if(mx==r){t=(g-b)/d;if(t<0)t+=6;h=60*t}
+		else if(mx==g){h=60*(((b-r)/d)+2)}
+		else{h=60*(((r-g)/d)+4)}
+	}
+	return h SUBSEP s SUBSEP v
+}
+function hsv2rgb(h,s,v,  hi,f,p,q,tm,rv,gv,bv) {
+	hi=int(h/60)%6; f=h/60-int(h/60)
+	p=v*(1-s); q=v*(1-f*s); tm=v*(1-(1-f)*s)
+	if(hi==0){rv=v;gv=tm;bv=p}
+	else if(hi==1){rv=q;gv=v;bv=p}
+	else if(hi==2){rv=p;gv=v;bv=tm}
+	else if(hi==3){rv=p;gv=q;bv=v}
+	else if(hi==4){rv=tm;gv=p;bv=v}
+	else{rv=v;gv=p;bv=q}
+	printf "%02x%02x%02x", int(rv*255), int(gv*255), int(bv*255)
+}
+BEGIN {
+	split(rgb2hsv(r,g,b), t, SUBSEP)
+	h=t[1]+0; s=t[2]+0; v=t[3]+0
+	ds=s*1.25; if(ds>1)ds=1; dv=v*0.80
+	hsv2rgb(h,ds,dv); printf "\n"
+	printf "%02x%02x%02x\n",r,g,b
+	ms=s*0.90; mv=v*1.10; if(mv>1)mv=1
+	hsv2rgb(h,ms,mv); printf "\n"
+	ls=s*0.75; lv=v*1.15; if(lv>1)lv=1
+	hsv2rgb(h,ls,lv); printf "\n"
+}'
+}
+
+msg() { printf '%s: %s\n' "${0##*/}" "$*"; } >&2
+
+# Find the WhiteSur theme name from gsettings
+detect_theme_name() {
+  local theme
+  theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null || true)"
+  theme="${theme//\'/}"
+  for candidate in "$theme" WhiteSur-dark WhiteSur-light WhiteSur; do
+    [[ -n "$candidate" ]] || continue
+    local base
+    for base in ~/.local/share/icons /usr/local/share/icons /usr/share/icons; do
+      [[ -f "$base/$candidate/index.theme" ]] || continue
+      printf '%s' "$candidate"
+      return 0
+    done
+  done
+  return 1
+}
+
+# Find the system (non-overlay) WhiteSur theme directory
+find_system_theme_dir() {
+  local name="$1"
+  local base
+  for base in /usr/local/share/icons /usr/share/icons; do
+    if [[ -f "$base/$name/index.theme" && ! -f "$base/$name/.whitesur-overlay" ]]; then
+      printf '%s' "$base/$name"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Apply color to one places directory (1x or 2x)
+apply_places() {
+  local vs="$1" tp="$2" color="$3"
+  mkdir -p "$tp"
+  find "$tp" -maxdepth 1 -name "*.svg" ! -name ".whitesur-overlay" -delete 2>/dev/null || true
+
+  if [[ "$color" == "blue" ]]; then
+    for v in "$vs"/folder*.svg "$vs"/user-*.svg "$vs"/default-*.svg \
+      "$vs"/folder_color_default*.svg "$vs"/gnome-*.svg \
+      "$vs"/gtk-*.svg "$vs"/inode-*.svg "$vs"/org.xfce.*.svg \
+      "$vs"/stock_*.svg; do
+      [[ -e "$v" ]] || continue
+      ln -sf "$v" "$tp/$(basename "$v")"
+    done
+  else
+    # Copy color variant files locally
+    for v in "$vs/${color}-"*.svg; do
+      [[ -f "$v" ]] || continue
+      cp -f "$v" "$tp/$(basename "$v")"
+    done
+
+    # Create base name symlinks → color variant
+    local v base
+    for v in "$tp/${color}-"*.svg; do
+      [[ -f "$v" ]] || continue
+      base="$(basename "$v")"
+      base="${base#${color}-}"
+      ln -sf "$(basename "$v")" "$tp/$base"
+    done
+
+    # default-folder*.svg → color variant
+    for v in "$vs/default-folder"*.svg "$vs/default-user"*.svg; do
+      [[ -L "$v" ]] || continue
+      local tbase inner
+      tbase="$(basename "$v")"
+      inner="${tbase#default-}"
+      [[ -e "$tp/${color}-${inner}" ]] && ln -sf "${color}-${inner}" "$tp/$tbase"
+    done
+
+    # folder_color_default*.svg → color variant
+    for v in "$vs"/folder_color_default*.svg; do
+      [[ -L "$v" ]] || continue
+      local tbase resolved rbase
+      tbase="$(basename "$v")"
+      resolved="$(readlink -f "$v")"
+      rbase="$(basename "$resolved")"
+      [[ -e "$tp/${color}-${rbase}" ]] && ln -sf "${color}-${rbase}" "$tp/$tbase"
+    done
+
+    # Generic aliases
+    local aliases=(gnome-folder gnome-fs-directory gtk-directory inode-directory
+      stock_folder org.xfce.panel.directorymenu)
+    if [[ -e "$tp/${color}-folder.svg" ]]; then
+      for a in "${aliases[@]}"; do
+        ln -sf "${color}-folder.svg" "$tp/$a.svg"
+      done
+    fi
+  fi
+
+  # Symlink remaining system SVGs not yet in overlay
+  local v bname
+  for v in "$vs"/*.svg; do
+    bname="$(basename "$v")"
+    [[ -e "$tp/$bname" ]] && continue
+    ln -sf "$v" "$tp/$bname"
+  done
+
+  # Recolor non-blue SVGs that contain the default Blue palette
+  if [[ "$color" != "blue" ]]; then
+    local hexrec variants vr_main vr_dark vr_med vr_light tmp f
+    hexrec="$(color_hex "$color")"
+    variants="$(color_variants "$hexrec")"
+    vr_dark="$(sed -n '1p' <<<"$variants")"
+    vr_main="$(sed -n '2p' <<<"$variants")"
+    vr_med="$(sed -n '3p' <<<"$variants")"
+    vr_light="$(sed -n '4p' <<<"$variants")"
+    for f in "$tp"/*.svg; do
+      [[ -f "$f" ]] || continue
+      grep -q '#46a2d7\|#008ea2\|#60c0f0\|#83d4fb' "$f" || continue
+      tmp="${f}.tmp.$$"
+      sed -e "s/#008ea2/#${vr_dark}/g" \
+        -e "s/#46a2d7/#${vr_main}/g" \
+        -e "s/#60c0f0/#${vr_med}/g" \
+        -e "s/#83d4fb/#${vr_light}/g" \
+        "$f" >"$tmp" && mv "$tmp" "$f"
+    done
+  fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+theme_name="$(detect_theme_name)" || {
+  msg "WhiteSur icon theme is not installed"
+  exit 1
+}
+
+usr="$HOME/.local/share/icons/$theme_name"
+sys="$(find_system_theme_dir "$theme_name")" || {
+  msg "WhiteSur system theme not found"
+  exit 1
+}
+
+mkdir -p "$usr"
+
+# Copy full system index.theme (not minimal — resolver needs all directories)
+[[ -f "$usr/.whitesur-overlay" ]] || {
+  cp -f "$sys/index.theme" "$usr/index.theme"
+  touch "$usr/.whitesur-overlay"
+}
+
+# Symlink non-places directories from system theme
+for dir in "$sys"/*/; do
+  [[ -d "$dir" ]] || continue
+  bname="$(basename "$dir")"
+  [[ "$bname" == "places" || "$bname" == "places@2x" ]] && continue
+  [[ -e "$usr/$bname" ]] || ln -sf "$dir" "$usr/$bname"
+done
+
+# Apply color to places icons
+apply_places "$sys/places/scalable" "$usr/places/scalable" "$COLOR"
+[[ -d "$sys/places@2x/scalable" ]] &&
+  apply_places "$sys/places@2x/scalable" "$usr/places@2x/scalable" "$COLOR"
+
+# Trash icons — no color variants
+for ai in user-trash user-trash-full; do
+  for src in "$sys/places/scalable/$ai.svg" "$sys/places@2x/scalable/$ai.svg"; do
+    [[ -f "$src" ]] || continue
+    tp="$usr/places/scalable"
+    [[ "$src" == *places@2x* ]] && tp="$usr/places@2x/scalable"
+    ln -sf "$src" "$tp/$ai.svg"
+  done
+done
+
+gtk-update-icon-cache --force --quiet "$usr" 2>/dev/null || true


### PR DESCRIPTION
Dynamic folder color template for WhiteSur icon theme. Applies the closest palette color to match wallpaper tone.

Requires WhiteSur icon theme installed via package manager.