### PR TITLE
fix(papirus-icons): recolor all Papirus variants and sync icon-theme to mode

### DIFF
--- a/papirus-icons/apply.sh
+++ b/papirus-icons/apply.sh
@@ -20,6 +20,17 @@ set -euo pipefail
   # 3. Extract the mapping array
   MAPPING="${lines[${#lines[@]}-1]}"
 
+  # 3b. Derive dark/light from the surface (background) color's luminance, and point GTK's icon theme at the matching Papirus variant.
+  SURFACE="${lines[1]//[# ]/}"
+  if [[ ${#SURFACE} -ge 6 ]]; then
+    SURFACE=${SURFACE:0:6}
+    SR=$((16#${SURFACE:0:2})); SG=$((16#${SURFACE:2:2})); SB=$((16#${SURFACE:4:2}))
+    LUMA=$(( (SR*299 + SG*587 + SB*114) / 1000 ))
+    ICON_VARIANT="Papirus-Dark"; (( LUMA >= 128 )) && ICON_VARIANT="Papirus-Light"
+    command -v gsettings >/dev/null 2>&1 && \
+      gsettings set org.gnome.desktop.interface icon-theme "$ICON_VARIANT" 2>/dev/null || true
+  fi
+
   # 4. Math calculation (HSV-based)
   closest=$(
     awk -v r="$TR" -v g="$TG" -v b="$TB" -v m="$MAPPING" '
@@ -84,17 +95,16 @@ set -euo pipefail
     }
   ')
 
-  # 5. Ensure user icon directory is created so papirus-folders doesn't need to be called as root
-  if [[ ! -d $HOME/.local/share/icons/Papirus ]]; then
-    mkdir -p "$HOME/.local/share/icons"
+  # 5/6. Recolor every installed Papirus variant, not just the base one so Papirus-Dark and Papirus-Light stay in sync too
+  [[ -n "$closest" ]] || { echo "Error: no matching folder color found" 1>&2; exit 0; }
 
-    if [[ -d "/usr/share/icons/Papirus" ]]; then
-      cp -r "/usr/share/icons/Papirus" "$HOME/.local/share/icons/"
-    else
-      echo "Error: Papirus Icons are not installed" 1>&2; exit 1
+  for variant in Papirus Papirus-Dark Papirus-Light; do
+    [[ -d "/usr/share/icons/$variant" ]] || continue
+    if [[ ! -d "$HOME/.local/share/icons/$variant" ]]; then
+      mkdir -p "$HOME/.local/share/icons"
+      cp -r "/usr/share/icons/$variant" "$HOME/.local/share/icons/"
     fi
-  fi
-
-  # 6. Apply icons instantly
-  [[ -n "$closest" ]] && "$(dirname "$0")/papirus-folders" -C "$closest" || echo "Error: Failed to apply papirus-folders"
+    "$(dirname "$0")/papirus-folders" -t "$variant" -C "$closest" \
+      || echo "Error: papirus-folders failed for $variant" 1>&2
+  done
 }

--- a/papirus-icons/colors
+++ b/papirus-icons/colors
@@ -1,3 +1,4 @@
 {{ colors.source_color.default.hex }}
+{{ colors.surface.default.hex }}
 
 adwaita:93c0ea black:4f4f4f blue:5294e2 bluegrey:607d8b breeze:57b8ec brown:ae8e6c carmine:a30002 cyan:00bcd4 darkcyan:45abb7 deeporange:eb6637 green:87b158 grey:8e8e8f indigo:5c6bc0 magenta:ca71df nordic:81a1c1 orange:ee923a palebrown:d1bfae paleorange:eeca8f pink:f06292 red:e25252 teal:16a085 violet:7e57c2 white:e4e4e4 yaru:676767 yellow:f9bd30


### PR DESCRIPTION
## Template

- **App:** Papirus Icon Theme
- **Template id (directory):** papirus-icons
- [ ] New template
- [x] Update to an existing template

## What it themes

Originally the script only updated the color for the "Papirus" icon theme, this PR just extends that to also update the "Dark" and "Light" variants as well as automatically switching between the two when changing from light to dark theme and vice versa.

## Testing

- **App version tested:** 20260801
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/7e3c2227-47e7-4ec1-b412-d0860df0c5db" />
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/d16a4616-6195-4102-a40f-96eec5e03db0" />

Note: I did not manually change the icon theme from the dark variant to the light variant, the changes made to the script did that

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
