### PR TITLE
fix(herdr): make workspace bar background transparent

### DIFF
--- a/herdr/herdr-colors.toml
+++ b/herdr/herdr-colors.toml
@@ -1,5 +1,5 @@
 accent = "{{colors.primary.default.hex}}"
-panel_bg = "{{colors.surface_container.default.hex}}"
+panel_bg = "reset"
 sidebar_bg = "reset"
 active_row_bg = "{{colors.surface_container_high.default.hex}}"
 selection_bg = "{{colors.surface_container_highest.default.hex}}"


### PR DESCRIPTION
## Summary
- Set `panel_bg` to `reset` in the Herdr template so the workspace/tab bar uses the host terminal background instead of a solid surface color
- Matches the existing `sidebar_bg = "reset"` behavior for transparent panel chrome

## Test plan
- [x] Enable the Herdr template in Noctalia with an existing `~/.config/herdr/config.toml`
- [x] Apply a theme change and confirm `[theme.custom]` has `panel_bg = "reset"`
- [x] Verify the workspace bar background is transparent after `herdr server reload-config`


Made with [Cursor](https://cursor.com)