### PR TITLE
Feat(Jay): Add jay template

### DIFF
--- a/jay/apply.sh
+++ b/jay/apply.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fall back to the passwd entry if $HOME wasn't handed to us at all.
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}"
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}"
+config_file="$config_dir/jay/config.toml"
+theme_file="$cache_dir/noctalia/templates/jay-theme.toml"
+
+if [ ! -f "$config_file" ]; then
+  echo "ERROR: jay config not found at $config_file"
+  exit 1
+fi
+
+if [ ! -f "$theme_file" ]; then
+  echo "ERROR: rendered theme fragment not found at $theme_file"
+  exit 1
+fi
+
+fragment="$(cat "$theme_file")"
+
+if ! grep -q '^\[theme\]' "$config_file"; then
+  # No [theme] table yet at all — cheap append, nothing to merge with.
+  printf '\n%s\n' "$fragment" >>"$config_file"
+  echo "OK: appended theme (first run)"
+  exit 0
+fi
+
+# The key names our fragment defines (ignoring the [theme] header itself,
+# comments, and blank lines). Only these keys get touched inside an
+# existing [theme] table — anything else the user put there is kept as-is.
+managed_keys="$(printf '%s\n' "$fragment" |
+  grep -E '^[A-Za-z0-9_-]+[[:space:]]*=' |
+  sed -E 's/^([A-Za-z0-9_-]+).*/\1/' |
+  paste -sd'|' -)"
+echo "managed_keys=$managed_keys"
+
+tmp="$(mktemp "$config_dir/jay/config.toml.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+awk -v frag="$fragment" -v keys="$managed_keys" '
+    BEGIN { keypat = "^(" keys ")[[:space:]]*=" }
+    !replaced && /^\[theme\]/ {
+        print frag
+        replaced = 1
+        in_theme = 1
+        next
+    }
+    in_theme && /^\[/ && !/^\[theme\]/ && !/^\[theme\./ { in_theme = 0 }
+    in_theme {
+        if ($0 ~ keypat) next   # one of ours — already emitted via frag
+        print                   # user-defined key, comment, or blank line
+        next
+    }
+    { print }
+    END { if (!replaced) { print ""; print frag } }
+' "$config_file" >"$tmp"
+
+mv "$tmp" "$config_file"
+echo "OK: theme merged"

--- a/jay/jay.toml
+++ b/jay/jay.toml
@@ -1,0 +1,13 @@
+[theme]
+border-color = "#{{colors.surface.default.hex_stripped}}"
+focused-border-color = "#{{colors.primary.default.hex_stripped}}"
+focused-title-bg-color = "#{{colors.surface.default.hex_stripped}}"
+focused-title-text-color = "#{{colors.on_surface.default.hex_stripped}}"
+unfocused-title-bg-color = "#{{colors.surface.default.hex_stripped}}"
+unfocused-title-text-color = "#{{colors.on_surface_variant.default.hex_stripped}}"
+focused-inactive-title-bg-color = "#{{colors.surface.default.hex_stripped}}"
+focused-inactive-title-text-color = "#{{colors.on_surface_variant.default.hex_stripped}}"
+attention-requested-bg-color = "#{{colors.error.default.hex_stripped}}"
+separator-color = "#{{colors.surface.default.hex_stripped}}"
+highlight-color = "#{{colors.on_surface_variant.default.hex_stripped}}"
+

--- a/jay/template.toml
+++ b/jay/template.toml
@@ -1,0 +1,8 @@
+[catalog.jay]
+name = "Jay"
+category = "compositor"
+
+[templates.jay]
+input_path = "jay.toml"
+output_path = "$XDG_CACHE_HOME/noctalia/templates/jay-theme.toml"
+post_hook = "bash '{{ config_dir }}/apply.sh'"


### PR DESCRIPTION


## Template

- **App:** Jay
- **Template id (directory):** `<id>`
- [x] New template
- [ ] Update to an existing template

## What it themes

borders, titles and title-backgrounds in their active and inactive states.

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** Jay  1.14.0
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<img width="1920" height="1080" alt="desktop" src="https://github.com/user-attachments/assets/597008a5-af22-4cfd-b9ba-a3ed1ba2c52a" />

## Hooks

- **What the hook does:** Finds a pre-existing [Theme] section in the jay config.toml and appends the relevant colour lines to it, if it doesn't exist it creates one. anything that isn't themed by the template, e.g: title fonts is left undisturbed in the theme section.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
