### PR TITLE
Add templates for flatpak version of vesktop

### DIFF
--- a/discord/template.toml
+++ b/discord/template.toml
@@ -14,6 +14,18 @@ output_path = "$XDG_CONFIG_HOME/vesktop/themes/noctalia-material.theme.css"
 input_path = "discord-system24.css"
 output_path = "$XDG_CONFIG_HOME/vesktop/themes/discord-system24.css"
 
+[templates.discord_midnight_vesktop_flatpak]
+input_path = "discord-midnight.css"
+output_path = "~/.var/app/dev.vencord.Vesktop/config/vesktop/themes/noctalia.theme.css"
+
+[templates.discord_material_vesktop_flatpak]
+input_path = "discord-material.css"
+output_path = "~/.var/app/dev.vencord.Vesktop/config/vesktop/themes/noctalia-material.theme.css"
+
+[templates.discord_system24_vesktop_flatpak]
+input_path = "discord-system24.css"
+output_path = "~/.var/app/dev.vencord.Vesktop/config/vesktop/themes/discord-system24.css"
+
 [templates.discord_midnight_webcord]
 input_path = "discord-midnight.css"
 output_path = "$XDG_CONFIG_HOME/webcord/themes/noctalia.theme.css"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Template

- **App:** Vesktop (flatpak) <!-- e.g. Fuzzel -->
- **Template id (directory):** `~/.var/app/dev.vencord.Vesktop/config/vesktop/themes` <id>
- [ ] New template
- [ ] Update to an existing template
- [x] Extended template support

## What it themes

<!-- Which config file(s) of the app get rendered, and what the user sees change. -->
Flatpak version of vesktop now gets themed automatically like everything else.

## Testing

<!-- Test it as a user template first (see the README), then say what you ran. -->

- **App version tested:** Vesktop 1.6.7 <!-- e.g. fuzzel 1.11.0 -->
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

## Screenshots

<!-- The app running with the theme applied. Required. -->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2841e270-85e5-4c04-8fa8-569eed7e04c4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/25853ed1-515d-41f5-8c20-4bd2c78768b6" />

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
