### PR TITLE
fix: make apply.sh self-contained and detect official TDF installed libreoffice

### DIFF
--- a/libreoffice/META-INF/manifest.xml
+++ b/libreoffice/META-INF/manifest.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest:manifest xmlns:manifest="http://openoffice.org/2001/manifest">
-  <manifest:file-entry manifest:full-path="Theme_Colors.xcu" manifest:media-type="application/vnd.sun.star.configuration-data"/>
-  <manifest:file-entry manifest:full-path="Paths.xcu" manifest:media-type="application/vnd.sun.star.configuration-data"/>
-</manifest:manifest>

--- a/libreoffice/README.md
+++ b/libreoffice/README.md
@@ -80,12 +80,16 @@ roles stretched over a dozen token types. These are functional, not chrome.
 
 ## Native install
 
-Same `unopkg` mechanism, invoked directly (`apply.sh` detects whether `unopkg` is already on
-`PATH` and uses it, falling back to the Flatpak `flatpak run --command=` form only if not).
-**Not verified live** on this machine, only Flatpak LibreOffice is installed here. The install
-command itself is the same either way, only how it's invoked differs, but if something about a
-native install's `unopkg`/extension-cache path differs from what's documented above, this hasn't
-been caught yet the way the Flatpak-specific issues above were.
+Same `unopkg` mechanism, invoked directly. `apply.sh` resolves `unopkg` from `PATH` first, then
+falls back to the official TDF install layout (`/opt/libreoffice*/program/unopkg`,
+`/usr/lib/libreoffice/program/unopkg`, `/usr/lib64/libreoffice/program/unopkg`) so the official
+`.deb`/`.rpm` packages, which do **not** put `unopkg` on `PATH`, are detected too. If no native
+`unopkg` is found it falls back to the Flatpak `flatpak run --command=` form.
+
+**Verified live** against LibreOffice 26.2.4.2 from the official TDF `.deb` packages on
+Kali Linux (amd64), including a clean-PATH run where `command -v unopkg` returned nothing and
+`/opt/libreoffice26.2/program/unopkg` was picked up by the fallback; the extension installed
+and registered correctly.
 
 ## Flatpak install (`org.libreoffice.LibreOffice`)
 

--- a/libreoffice/apply.sh
+++ b/libreoffice/apply.sh
@@ -41,7 +41,20 @@ PYEOF
 cp "$CONFIG_DIR/Paths.xcu" "$BUILD_DIR/pkg/Paths.xcu"
 cp "$CONFIG_DIR/description.xml" "$BUILD_DIR/pkg/description.xml"
 cp "$CONFIG_DIR/pkg-description.en" "$BUILD_DIR/pkg/pkg-description.en"
-cp "$CONFIG_DIR/META-INF/manifest.xml" "$BUILD_DIR/pkg/META-INF/manifest.xml"
+
+# Write the package manifest inline rather than copying it from the template directory.
+# The template distribution pipeline only ships top-level files, so the
+# META-INF/manifest.xml that used to live here was never delivered to users and
+# the previous `cp` aborted under set -euo pipefail before the .oxt was built.
+# The manifest is static and small, so generating it here keeps the template
+# self-contained and removes the only subdirectory dependency.
+cat > "$BUILD_DIR/pkg/META-INF/manifest.xml" <<'MANIFEST'
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest:manifest xmlns:manifest="http://openoffice.org/2001/manifest">
+  <manifest:file-entry manifest:full-path="Theme_Colors.xcu" manifest:media-type="application/vnd.sun.star.configuration-data"/>
+  <manifest:file-entry manifest:full-path="Paths.xcu" manifest:media-type="application/vnd.sun.star.configuration-data"/>
+</manifest:manifest>
+MANIFEST
 
 rm -f "$OXT_PATH"
 (cd "$BUILD_DIR/pkg" && zip -qr "$OXT_PATH" .)
@@ -77,12 +90,29 @@ INSTALLED_ANY=0
 # LibreOffice (providing `unopkg` on PATH) and the Flatpak (the tested
 # target) installed would otherwise only get themed on whichever one won
 # that lookup, silently leaving the other one unthemed.
-if command -v unopkg >/dev/null 2>&1; then
-  unopkg remove "$EXT_ID" >/dev/null 2>&1 || true
-  if unopkg add --force "$OXT_PATH" 2>&1; then
+#
+# Native detection here also covers the official TDF `.deb`/`.rpm` layout,
+# which installs into /opt/libreoffice<major>.<minor>/ and does NOT place
+# `unopkg` on PATH. `command -v unopkg` alone misses it, so fall back to the
+# known install dirs before concluding there is no native install.
+UNOPKG="$(command -v unopkg || true)"
+if [ -z "$UNOPKG" ]; then
+  for candidate in /opt/libreoffice*/program/unopkg \
+                   /usr/lib/libreoffice/program/unopkg \
+                   /usr/lib64/libreoffice/program/unopkg; do
+    if [ -x "$candidate" ]; then
+      UNOPKG="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -n "$UNOPKG" ]; then
+  "$UNOPKG" remove "$EXT_ID" >/dev/null 2>&1 || true
+  if "$UNOPKG" add --force "$OXT_PATH" 2>&1; then
     INSTALLED_ANY=1
   else
-    echo "noctalia libreoffice: native unopkg install failed" >&2
+    echo "noctalia libreoffice: native unopkg install failed ($UNOPKG)" >&2
   fi
 fi
 


### PR DESCRIPTION
Closes #107

## Problem

The `libreoffice` template never applies on a native install. Two independent issues on the same code path:

### 1. `META-INF/manifest.xml` is not distributed

`libreoffice/META-INF/manifest.xml` exists in the repo but the template pipeline only ships top-level files, so it never reaches users. `apply.sh` copies it under `set -euo pipefail`:

```bash
cp "$CONFIG_DIR/META-INF/manifest.xml" "$BUILD_DIR/pkg/META-INF/manifest.xml"
```

Line 44 `cp` fails, `set -e` aborts before `zip` (line 47) ever runs, so no `.oxt` is built and nothing installs. The rendered staging file writes normally, so the template looks active but does nothing.

### 2. `command -v unopkg` misses official TDF `.deb`/`.rpm`

The official LibreOffice download installs to `/opt/libreoffice<major>.<minor>/` and does **not** put `unopkg` on `PATH`. With only that layout present (no Flatpak), the 'no LibreOffice installation found' path triggers on a machine where LibreOffice is installed and running.

## Fix

- Write `manifest.xml` inline in `apply.sh` and drop the `META-INF/` directory. This removes the only subdirectory dependency and keeps the template self-contained.
- When `command -v unopkg` returns nothing, fall back to the known install dirs (`/opt/libreoffice*/program/unopkg`, `/usr/lib/libreoffice/program/unopkg`, `/usr/lib64/libreoffice/program/unopkg`).

## Verification

As you can see, the fix I wrote has taken effect. When applied to LibreOffice 26.2.4.2 (official TDF deb, Kali amd64), the color-scheme of LibreOffice now matches and harmonizes with my wallpaper and the entire desktop.

<img width="1915" height="1079" alt="图片" src="https://github.com/user-attachments/assets/49e738f1-c81d-43ed-9b57-d232b80530e2" />
<img width="1914" height="1076" alt="图片" src="https://github.com/user-attachments/assets/a5303d8c-3525-4d53-9023-1ab5dc256e3d" />

Tested against LibreOffice 26.2.4.2 from the official TDF `.deb` packages on Kali Linux (amd64), including a clean-`PATH` run where `command -v unopkg` returned nothing:

- `apply.sh` builds `noctalia-theme.oxt` containing `META-INF/manifest.xml`
- the extension installs via the `/opt` fallback and registers as `is registered: yes`
- all 42 color values convert hex→decimal correctly

![LibreOffice with Noctalia theme applied](PASTE_IMAGE_1_HERE)

![LibreOffice Writer themed](PASTE_IMAGE_2_HERE)

Note: this addresses the observable failure on the template side. If the catalog/distribution pipeline is also expected to support nested files for other templates, that is a separate change on the distribution side; this PR makes the libreoffice template not depend on it.
