### PR TITLE
Add Archetype (PokeMMO) template

### DIFF
--- a/archetype-pokemmo/README.md
+++ b/archetype-pokemmo/README.md
@@ -58,7 +58,7 @@ Verified with dark mode, light mode, wallpaper-derived `m3-content`, a second wa
 
 ## AI note
 
-**This template was vibecoded with AI assistance.**
+**This template was fully vibecoded using AI assistance.**
 
 ## Upstream
 

--- a/archetype-pokemmo/README.md
+++ b/archetype-pokemmo/README.md
@@ -1,0 +1,70 @@
+# Archetype (PokeMMO)
+
+Synchronizes the **Archetype** PokeMMO theme with Noctalia's active color palette.
+
+When the Noctalia palette changes, this community template renders matching colors and updates only Archetype's exposed color constants in `CHOOSE_YOUR_COLORS.xml`.
+
+## Requirements
+
+- Noctalia v5+
+- PokeMMO desktop client
+- Archetype Theme
+- Python 3
+
+**PokeManager is supported but not required.**
+
+## Color ownership
+
+While **Archetype (PokeMMO)** is enabled:
+
+- Noctalia owns Archetype colors.
+- PokeManager can still install or update Archetype, manage other Archetype settings, and manage PokeMMO mods.
+- If you want to manually customize Archetype colors, disable this Noctalia template first.
+
+Disabling the community template stops future color synchronization. Noctalia's current community-template manifest does not provide an undo hook, so Archetype keeps the last applied colors until you change them again.
+
+## What changes
+
+The template renders a small palette file into Noctalia's cache. Its hook then patches only existing named `<constantDef>` color values in Archetype's:
+
+`theme/CHOOSE_YOUR_COLORS.xml`
+
+The complete Archetype XML file is not replaced.
+
+Normal UI roles follow Noctalia's resolved Material palette. HP and warning colors keep semantic green, yellow, and red values so they remain recognizable in both dark and light mode.
+
+If PokeMMO is already running, press **Ctrl+F5** in PokeMMO after a palette change to reload Archetype.
+
+## Linux install discovery
+
+The hook checks:
+
+1. `POKEMMO_ARCHETYPE_COLORS_FILE`, when explicitly set
+2. the standard PokeMMO Flatpak data location
+3. `~/PokeMMO/`
+4. `~/.local/share/PokeMMO/`
+
+The official portable Linux client may be extracted anywhere. For a non-standard portable location, set `POKEMMO_ARCHETYPE_COLORS_FILE` to the exact `CHOOSE_YOUR_COLORS.xml` path in the environment that launches Noctalia.
+
+## Tested
+
+- Noctalia v5.0.1
+- Archetype Theme v1.8, theme revision 8
+- PokeMMO Linux Flatpak
+- CachyOS
+- Hyprland / Wayland
+
+Verified with dark mode, light mode, wallpaper-derived `m3-content`, a second wallpaper palette, and repeated template application.
+
+## AI note
+
+**This template was vibecoded with AI assistance.**
+
+## Upstream
+
+- Noctalia: <https://github.com/noctalia-dev/noctalia>
+- Archetype: <https://github.com/ssjshields/archetype>
+- PokeMMO: <https://pokemmo.com/>
+- PokeManager, optional: <https://github.com/Ryukotsuki/Poke-Manager>
+
+This community template is not an official component of PokeMMO, Archetype, or PokeManager.

--- a/archetype-pokemmo/apply.py
+++ b/archetype-pokemmo/apply.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Apply Noctalia colors to Archetype's existing color constants."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+PALETTE = (
+    Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    / "noctalia/archetype-pokemmo/colors.json"
+)
+
+COLOR_RE = re.compile(
+    r'(?P<prefix><constantDef\s+name=["\'](?P<name>[^"\']+)["\']\s*>\s*<color>)'
+    r'(?P<value>#[0-9A-Fa-f]{6,8})'
+    r'(?P<suffix></color>\s*</constantDef>)'
+)
+
+REQUIRED = {
+    "main-color",
+    "sub-color",
+    "button-color",
+    "accent-color",
+    "font-main-color",
+}
+
+
+def fail(message: str) -> int:
+    print(f"Archetype (PokeMMO): {message}", file=sys.stderr)
+    return 1
+
+
+def find_target() -> Path | None:
+    override = os.environ.get("POKEMMO_ARCHETYPE_COLORS_FILE")
+    candidates = []
+
+    if override:
+        candidates.append(Path(override).expanduser())
+
+    candidates += [
+        Path.home()
+        / ".var/app/com.pokemmo.PokeMMO/data/pokemmo-client-live"
+        / "data/mods/archetype-theme/theme/CHOOSE_YOUR_COLORS.xml",
+        Path.home()
+        / "PokeMMO/data/mods/archetype-theme/theme/CHOOSE_YOUR_COLORS.xml",
+        Path.home()
+        / ".local/share/PokeMMO/data/mods/archetype-theme/theme/CHOOSE_YOUR_COLORS.xml",
+    ]
+
+    for path in candidates:
+        if path.is_file():
+            return path
+
+    return None
+
+
+def write_atomic(path: Path, text: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    fd, temp_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
+        os.chmod(temp_name, mode)
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def main() -> int:
+    if not PALETTE.is_file():
+        return fail(f"rendered palette is missing: {PALETTE}")
+
+    try:
+        colors = json.loads(PALETTE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return fail(f"could not read rendered palette: {error}")
+
+    if not isinstance(colors, dict):
+        return fail("rendered palette is not a JSON object")
+
+    invalid = {
+        name: value
+        for name, value in colors.items()
+        if not isinstance(value, str)
+        or re.fullmatch(r"#[0-9A-Fa-f]{6,8}", value) is None
+    }
+    if invalid:
+        return fail(f"rendered palette contains invalid color values: {invalid}")
+
+    target = find_target()
+    if target is None:
+        return fail(
+            "Archetype CHOOSE_YOUR_COLORS.xml was not found. "
+            "Install Archetype, or set POKEMMO_ARCHETYPE_COLORS_FILE."
+        )
+
+    try:
+        source = target.read_text(encoding="utf-8")
+    except OSError as error:
+        return fail(f"could not read {target}: {error}")
+
+    present = {match.group("name") for match in COLOR_RE.finditer(source)}
+    missing = REQUIRED - present
+    if missing:
+        return fail(
+            "Archetype's color file has an unexpected structure; missing: "
+            + ", ".join(sorted(missing))
+        )
+
+    changed = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal changed
+        name = match.group("name")
+        value = colors.get(name)
+        if value is None:
+            return match.group(0)
+        if value.lower() != match.group("value").lower():
+            changed += 1
+        return match.group("prefix") + value + match.group("suffix")
+
+    rendered = COLOR_RE.sub(replace, source)
+
+    if changed:
+        try:
+            write_atomic(target, rendered)
+        except OSError as error:
+            return fail(f"could not update {target}: {error}")
+
+    print(f"Archetype (PokeMMO): synced {changed} color value(s).")
+    if changed:
+        print("If PokeMMO is open, press Ctrl+F5 in PokeMMO to reload Archetype.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/archetype-pokemmo/archetype-colors-dark.json
+++ b/archetype-pokemmo/archetype-colors-dark.json
@@ -1,0 +1,38 @@
+{
+  "main-color": "{{ colors.primary.default.hex }}",
+  "sub-color": "{{ colors.surface.default.hex }}",
+  "button-color": "{{ colors.surface_container.default.hex }}",
+  "accent-color": "{{ colors.surface_container_high.default.hex }}",
+
+  "font-main-color": "{{ colors.on_surface.default.hex }}",
+  "font-sub-color": "{{ colors.on_surface_variant.default.hex }}",
+  "font-button-color": "{{ colors.outline.default.hex }}",
+  "font-disabled-color": "#99{{ colors.on_surface_variant.default.hex_stripped }}",
+
+  "hp-high-color": "#82e026",
+  "hp-mid-color": "#ecd031",
+  "hp-low-color": "#dc2222",
+
+  "xp-color": "{{ colors.secondary.default.hex }}",
+  "friendship-color": "{{ colors.tertiary.default.hex }}",
+  "icon-color": "{{ colors.on_surface.default.hex }}",
+
+  "water-background": "#D9{{ colors.surface.default.hex_stripped }}",
+  "water-warning": "#dc2222",
+  "berry-progress": "{{ colors.primary.default.hex }}",
+  "berry-progress-warning": "#dc2222",
+  "berry-progress-disabled": "#42{{ colors.on_surface.default.hex_stripped }}",
+
+  "reshiram-color": "{{ colors.surface_container_low.default.hex }}",
+  "reshiram-aura": "{{ colors.tertiary.default.hex }}",
+  "zekrom-color": "{{ colors.surface_container_lowest.default.hex }}",
+  "zekrom-aura": "{{ colors.primary.default.hex }}",
+
+  "counter-ball-color": "{{ colors.primary.default.hex }}",
+  "counter-ball-outline": "{{ colors.on_primary.default.hex }}",
+  "counter-min-max-button-color": "{{ colors.on_surface.default.hex }}",
+  "counter-main-color": "{{ colors.primary.default.hex }}",
+  "counter-sub-color": "{{ colors.surface.default.hex }}",
+  "counter-font": "{{ colors.on_surface.default.hex }}",
+  "counter-font-border": "{{ colors.surface_container_highest.default.hex }}"
+}

--- a/archetype-pokemmo/archetype-colors-light.json
+++ b/archetype-pokemmo/archetype-colors-light.json
@@ -1,0 +1,38 @@
+{
+  "main-color": "{{ colors.primary.default.hex }}",
+  "sub-color": "{{ colors.surface.default.hex }}",
+  "button-color": "{{ colors.surface_container.default.hex }}",
+  "accent-color": "{{ colors.surface_container_high.default.hex }}",
+
+  "font-main-color": "{{ colors.on_surface.default.hex }}",
+  "font-sub-color": "{{ colors.on_surface_variant.default.hex }}",
+  "font-button-color": "{{ colors.outline.default.hex }}",
+  "font-disabled-color": "#99{{ colors.on_surface_variant.default.hex_stripped }}",
+
+  "hp-high-color": "#4f7f18",
+  "hp-mid-color": "#8b6d00",
+  "hp-low-color": "#b3261e",
+
+  "xp-color": "{{ colors.secondary.default.hex }}",
+  "friendship-color": "{{ colors.tertiary.default.hex }}",
+  "icon-color": "{{ colors.on_surface.default.hex }}",
+
+  "water-background": "#D9{{ colors.surface.default.hex_stripped }}",
+  "water-warning": "#b3261e",
+  "berry-progress": "{{ colors.primary.default.hex }}",
+  "berry-progress-warning": "#b3261e",
+  "berry-progress-disabled": "#42{{ colors.on_surface.default.hex_stripped }}",
+
+  "reshiram-color": "{{ colors.surface_container_low.default.hex }}",
+  "reshiram-aura": "{{ colors.tertiary.default.hex }}",
+  "zekrom-color": "{{ colors.surface_container_lowest.default.hex }}",
+  "zekrom-aura": "{{ colors.primary.default.hex }}",
+
+  "counter-ball-color": "{{ colors.primary.default.hex }}",
+  "counter-ball-outline": "{{ colors.on_primary.default.hex }}",
+  "counter-min-max-button-color": "{{ colors.on_surface.default.hex }}",
+  "counter-main-color": "{{ colors.primary.default.hex }}",
+  "counter-sub-color": "{{ colors.surface.default.hex }}",
+  "counter-font": "{{ colors.on_surface.default.hex }}",
+  "counter-font-border": "{{ colors.surface_container_highest.default.hex }}"
+}

--- a/archetype-pokemmo/template.toml
+++ b/archetype-pokemmo/template.toml
@@ -1,0 +1,9 @@
+[catalog.archetype-pokemmo]
+name = "Archetype (PokeMMO)"
+category = "gaming"
+
+[templates.archetype-pokemmo]
+input_path_modes = { dark = "archetype-colors-dark.json", light = "archetype-colors-light.json" }
+output_path = "$XDG_CACHE_HOME/noctalia/archetype-pokemmo/colors.json"
+post_hook = "python3 '{{ config_dir }}/apply.py'"
+hook_async = false


### PR DESCRIPTION
## Template

- **App:** Archetype (PokeMMO)
- **Template id (directory):** `archetype-pokemmo`
- [x] New template
- [ ] Update to an existing template

## What it themes

Synchronizes Archetype's exposed `CHOOSE_YOUR_COLORS.xml` color constants with Noctalia's resolved palette. The generated palette follows Noctalia for normal UI colors while HP and warning colors keep semantic green, yellow, and red values.

While the template is enabled, Noctalia owns Archetype colors. PokeManager is supported but not required.

**This contribution was fully vibecoded using AI assistance.**

## Testing

- **App version tested:** Archetype Theme v1.8, theme revision 8, with PokeMMO Linux Flatpak
- [x] Applied a dark theme and confirmed the app picked it up
- [x] Applied a light theme and confirmed the app picked it up
- [x] Re-applied twice and the app config is still correct (hooks are idempotent)

Also tested with Noctalia v5.0.1 on CachyOS, Hyprland, and Wayland using wallpaper-derived `m3-content` and a second wallpaper palette.

## Screenshots

Attach:
1. 
<img width="2560" height="1440" alt="01-archetype-pokemmo-noctalia-dark" src="https://github.com/user-attachments/assets/0adb2aa0-eb05-40e0-b030-29b7e6b3870b" />

2.
<img width="2560" height="1440" alt="02-archetype-pokemmo-noctalia-second-palette" src="https://github.com/user-attachments/assets/7e48cc25-917b-45b0-9d10-9af895b674e4" />

3.
<img width="2560" height="1440" alt="03-archetype-pokemmo-noctalia-light" src="https://github.com/user-attachments/assets/1fb3c844-0a2d-40c9-82b6-32ec2a7d66be" />


## Hooks

- **What the hook does:** Reads the Noctalia-rendered JSON palette and atomically replaces only existing named color constants in Archetype's `CHOOSE_YOUR_COLORS.xml`.
- [x] It is idempotent: running it twice does not duplicate lines or corrupt the config.
- [x] It fails loudly (non-zero exit, message on stderr) when the app's config is missing.
- [x] It downloads nothing and executes nothing it did not ship in this directory.
- [x] It touches only this app's own config.

## Checklist

- [x] The directory name matches the `[catalog.<id>]` id in `template.toml`.
- [x] `category` is one of: `ai`, `audio`, `browser`, `chat`, `compositor`, `editor`, `gaming`, `launcher`, `system`, `terminal`, `misc`.
- [x] Every `input_path` names a file that exists in this directory.
- [x] No generated output or app-specific personal config is committed.
